### PR TITLE
Add AWS AMI build pipeline for NixOS EC2 images

### DIFF
--- a/.github/workflows/ami-build-and-upload.yaml
+++ b/.github/workflows/ami-build-and-upload.yaml
@@ -1,0 +1,324 @@
+# AMI Build & Upload Pipeline
+#
+# Builds NixOS AMI images via Nix, uploads them to S3, imports as EBS snapshots,
+# registers as AMIs, and cleans up old images beyond the retention count.
+#
+# AWS Pre-requisites:
+#   1. GitHub OIDC Provider: https://token.actions.githubusercontent.com
+#      - Audience: sts.amazonaws.com
+#   2. IAM Role with trust policy allowing:
+#      - Federated principal: the OIDC provider ARN
+#      - Condition: token.actions.githubusercontent.com:sub like repo:alisonjenkins/nix-config:*
+#      - Permissions: s3:{PutObject,ListBucket,DeleteObject} on ajj-ami-builds bucket;
+#        ec2:{ImportSnapshot,DescribeImportSnapshotTasks,RegisterImage,DeregisterImage,
+#             DescribeImages,DescribeSnapshots,DeleteSnapshot,CreateTags}
+#   3. vmimport service role (required by ec2:ImportSnapshot):
+#      - Trusts vmie.amazonaws.com
+#      - S3 read on the bucket + EC2 snapshot permissions
+#   4. S3 bucket "ajj-ami-builds" in eu-west-2
+#   5. GitHub secret AWS_IAM_ROLE_ARN set to the role ARN
+
+name: Build and Upload AMIs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake-modules/ami-images.nix'
+      - 'hosts/aws-*/**'
+      - 'modules/aws/**'
+      - 'modules/servers/**'
+      - 'modules/locale/**'
+      - 'app-profiles/k8s-master/**'
+      - 'flake.lock'
+
+  workflow_dispatch:
+    inputs:
+      ami_name:
+        description: 'Which AMI to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - aws-base-server
+          - aws-k8s-node
+          # - aws-base-server-arm  # Uncomment when ARM runners are available
+          # - aws-k8s-node-arm
+      region:
+        description: 'AWS region'
+        required: true
+        default: 'eu-west-2'
+        type: string
+      retention_count:
+        description: 'Number of AMIs to keep per hostname'
+        required: true
+        default: '3'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      region: ${{ steps.params.outputs.region }}
+      retention_count: ${{ steps.params.outputs.retention_count }}
+    steps:
+      - name: Set build matrix
+        id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.ami_name }}" != "all" ]]; then
+            echo "matrix=[\"${{ inputs.ami_name }}\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=["aws-base-server","aws-k8s-node"]' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set parameters
+        id: params
+        run: |
+          echo "region=${{ inputs.region || 'eu-west-2' }}" >> "$GITHUB_OUTPUT"
+          echo "retention_count=${{ inputs.retention_count || '3' }}" >> "$GITHUB_OUTPUT"
+
+  build-and-upload:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        hostname: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    env:
+      AWS_REGION: ${{ needs.prepare.outputs.region }}
+      RETENTION_COUNT: ${{ needs.prepare.outputs.retention_count }}
+      S3_BUCKET: ajj-ami-builds
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: wimpysworld/nothing-but-nix@main
+        with:
+          hatchet-protocol: 'rampage'
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            max-jobs = auto
+            cores = 0
+            eval-cache = true
+            extra-substituters = https://ajenkins-public.cachix.org https://cosmic.cachix.org/ https://hyprland.cachix.org https://nix-community.cachix.org https://nix-gaming.cachix.org
+            extra-trusted-public-keys = ajenkins-public.cachix.org-1:w/uYRGLft8KxQhPtQI1KPBy6j2eZRR8vLZjgLIKntzA= cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4=
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: ajenkins-public
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build AMI
+        id: build
+        run: |
+          echo "Building AMI for ${{ matrix.hostname }}..."
+          OUT=$(cachix watch-exec ajenkins-public -- nix build ".#${{ matrix.hostname }}-ami" --print-out-paths --no-link)
+          echo "result=$OUT" >> "$GITHUB_OUTPUT"
+
+          # Extract image info
+          IMAGE_INFO="$OUT/nix-support/image-info.json"
+          echo "Image info:"
+          cat "$IMAGE_INFO" | jq .
+
+          VHD=$(find "$OUT" -name "*.vhd" | head -1)
+          echo "vhd=$VHD" >> "$GITHUB_OUTPUT"
+
+          SYSTEM=$(jq -r '.system // "x86_64-linux"' "$IMAGE_INFO")
+          BOOT_MODE=$(jq -r '.boot_mode // "uefi"' "$IMAGE_INFO")
+          case "$SYSTEM" in
+            aarch64-*) ARCH="arm64" ;;
+            *)         ARCH="x86_64" ;;
+          esac
+          echo "arch=$ARCH" >> "$GITHUB_OUTPUT"
+          echo "boot_mode=$BOOT_MODE" >> "$GITHUB_OUTPUT"
+          echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload VHD to S3
+        run: |
+          VHD="${{ steps.build.outputs.vhd }}"
+          S3_KEY="${{ matrix.hostname }}/${{ steps.build.outputs.timestamp }}/$(basename "$VHD")"
+          echo "s3_key=$S3_KEY" >> "$GITHUB_ENV"
+
+          echo "Uploading $VHD to s3://$S3_BUCKET/$S3_KEY..."
+          aws s3 cp "$VHD" "s3://$S3_BUCKET/$S3_KEY"
+
+      - name: Import EBS snapshot
+        id: import
+        timeout-minutes: 45
+        run: |
+          echo "Importing EBS snapshot..."
+          IMPORT_TASK=$(aws ec2 import-snapshot \
+            --description "NixOS AMI ${{ matrix.hostname }} ${{ steps.build.outputs.timestamp }}" \
+            --disk-container "Format=VHD,UserBucket={S3Bucket=$S3_BUCKET,S3Key=${{ env.s3_key }}}" \
+            --output json)
+
+          TASK_ID=$(echo "$IMPORT_TASK" | jq -r '.ImportTaskId')
+          echo "Import task: $TASK_ID"
+
+          echo "Waiting for snapshot import to complete..."
+          while true; do
+            STATUS=$(aws ec2 describe-import-snapshot-tasks \
+              --import-task-ids "$TASK_ID" \
+              --output json)
+
+            PROGRESS=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.Progress // "0"')
+            STATE=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.Status')
+
+            echo "  Status: $STATE ($PROGRESS%)"
+
+            if [ "$STATE" = "completed" ]; then
+              SNAPSHOT_ID=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.SnapshotId')
+              break
+            elif [ "$STATE" = "error" ]; then
+              echo "::error::Snapshot import failed"
+              echo "$STATUS" | jq '.ImportSnapshotTasks[0].SnapshotTaskDetail'
+              exit 1
+            fi
+
+            sleep 15
+          done
+
+          echo "snapshot_id=$SNAPSHOT_ID" >> "$GITHUB_OUTPUT"
+          echo "Snapshot imported: $SNAPSHOT_ID"
+
+      - name: Register AMI
+        id: register
+        run: |
+          SNAPSHOT_ID="${{ steps.import.outputs.snapshot_id }}"
+          ARCH="${{ steps.build.outputs.arch }}"
+          BOOT_MODE="${{ steps.build.outputs.boot_mode }}"
+          TIMESTAMP="${{ steps.build.outputs.timestamp }}"
+          AMI_NAME="nixos-${{ matrix.hostname }}-${TIMESTAMP}"
+
+          echo "Registering AMI: $AMI_NAME (arch=$ARCH, boot=$BOOT_MODE)..."
+          AMI_ID=$(aws ec2 register-image \
+            --name "$AMI_NAME" \
+            --description "NixOS AMI ${{ matrix.hostname }}" \
+            --architecture "$ARCH" \
+            --root-device-name /dev/xvda \
+            --block-device-mappings "DeviceName=/dev/xvda,Ebs={SnapshotId=$SNAPSHOT_ID,VolumeType=gp3}" \
+            --virtualization-type hvm \
+            --boot-mode "$BOOT_MODE" \
+            --ena-support \
+            --output text --query 'ImageId')
+
+          echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
+          echo "ami_name=$AMI_NAME" >> "$GITHUB_OUTPUT"
+
+          # Tag AMI
+          aws ec2 create-tags --resources "$AMI_ID" --tags \
+            "Key=Name,Value=$AMI_NAME" \
+            "Key=NixConfig,Value=${{ matrix.hostname }}" \
+            "Key=ManagedBy,Value=github-actions" \
+            "Key=GitCommit,Value=${{ github.sha }}" \
+            "Key=BuildTimestamp,Value=$TIMESTAMP"
+
+          # Tag snapshot
+          aws ec2 create-tags --resources "$SNAPSHOT_ID" --tags \
+            "Key=Name,Value=$AMI_NAME" \
+            "Key=NixConfig,Value=${{ matrix.hostname }}" \
+            "Key=ManagedBy,Value=github-actions" \
+            "Key=GitCommit,Value=${{ github.sha }}" \
+            "Key=BuildTimestamp,Value=$TIMESTAMP"
+
+          echo "AMI registered: $AMI_ID ($AMI_NAME)"
+
+      - name: Cleanup old AMIs
+        run: |
+          HOSTNAME="${{ matrix.hostname }}"
+          echo "Cleaning up old AMIs for $HOSTNAME (keeping $RETENTION_COUNT)..."
+
+          # List AMIs managed by this workflow for this hostname, sorted newest first
+          AMIS=$(aws ec2 describe-images \
+            --owners self \
+            --filters \
+              "Name=tag:ManagedBy,Values=github-actions" \
+              "Name=tag:NixConfig,Values=$HOSTNAME" \
+            --query 'Images | sort_by(@, &CreationDate) | reverse(@) | [*].[ImageId,CreationDate]' \
+            --output json)
+
+          TOTAL=$(echo "$AMIS" | jq 'length')
+          echo "Found $TOTAL AMIs for $HOSTNAME"
+
+          if [ "$TOTAL" -le "$RETENTION_COUNT" ]; then
+            echo "Nothing to clean up"
+          else
+            # Get AMIs beyond retention count
+            TO_DELETE=$(echo "$AMIS" | jq -r ".[$RETENTION_COUNT:][] | .[0]")
+            for AMI_ID in $TO_DELETE; do
+              echo "Deregistering $AMI_ID..."
+
+              # Find associated snapshots before deregistering
+              SNAP_IDS=$(aws ec2 describe-images \
+                --image-ids "$AMI_ID" \
+                --query 'Images[0].BlockDeviceMappings[*].Ebs.SnapshotId' \
+                --output json | jq -r '.[] // empty')
+
+              aws ec2 deregister-image --image-id "$AMI_ID"
+
+              for SNAP_ID in $SNAP_IDS; do
+                echo "  Deleting snapshot $SNAP_ID..."
+                aws ec2 delete-snapshot --snapshot-id "$SNAP_ID"
+              done
+            done
+          fi
+
+      - name: Cleanup old S3 uploads
+        run: |
+          HOSTNAME="${{ matrix.hostname }}"
+          echo "Cleaning up old S3 uploads for $HOSTNAME (keeping $RETENTION_COUNT)..."
+
+          # List timestamp directories (prefixes) for this hostname
+          PREFIXES=$(aws s3api list-objects-v2 \
+            --bucket "$S3_BUCKET" \
+            --prefix "$HOSTNAME/" \
+            --delimiter "/" \
+            --query 'CommonPrefixes[*].Prefix' \
+            --output json | jq -r '.[] // empty' | sort -r)
+
+          COUNT=0
+          for PREFIX in $PREFIXES; do
+            COUNT=$((COUNT + 1))
+            if [ "$COUNT" -gt "$RETENTION_COUNT" ]; then
+              echo "Deleting s3://$S3_BUCKET/$PREFIX..."
+              aws s3 rm "s3://$S3_BUCKET/$PREFIX" --recursive
+            fi
+          done
+
+          if [ "$COUNT" -le "$RETENTION_COUNT" ]; then
+            echo "Nothing to clean up"
+          fi
+
+      - name: Summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## AMI Build: ${{ matrix.hostname }}
+
+          | Field | Value |
+          |-------|-------|
+          | **AMI ID** | \`${{ steps.register.outputs.ami_id }}\` |
+          | **AMI Name** | \`${{ steps.register.outputs.ami_name }}\` |
+          | **Snapshot ID** | \`${{ steps.import.outputs.snapshot_id }}\` |
+          | **Region** | \`${{ env.AWS_REGION }}\` |
+          | **Architecture** | \`${{ steps.build.outputs.arch }}\` |
+          | **Boot Mode** | \`${{ steps.build.outputs.boot_mode }}\` |
+          | **Commit** | \`${{ github.sha }}\` |
+          EOF

--- a/flake-modules/ami-images.nix
+++ b/flake-modules/ami-images.nix
@@ -3,6 +3,10 @@ let
   lib = inputs.nixpkgs.lib;
   inherit (self) outputs;
 
+  # Common module for all AMIs — UEFI boot for NitroTPM, Secure Boot, and
+  # forward-compatibility with newer instance families.
+  commonAmiModule = { ec2.efi = true; };
+
   # Central registry of AMI configurations
   amiConfigs = {
     aws-base-server = {
@@ -15,7 +19,6 @@ let
       system = "aarch64-linux";
       hostConfig = ../hosts/aws-base-server/configuration.nix;
       extraModules = [{
-        ec2.efi = true;
         networking.hostName = lib.mkForce "aws-base-server-arm";
       }];
     };
@@ -30,7 +33,6 @@ let
       system = "aarch64-linux";
       hostConfig = ../hosts/aws-k8s-node/configuration.nix;
       extraModules = [{
-        ec2.efi = true;
         networking.hostName = lib.mkForce "aws-k8s-node-arm";
       }];
     };
@@ -48,6 +50,7 @@ let
 
       modules = [
         cfg.hostConfig
+        commonAmiModule
       ] ++ cfg.extraModules;
     };
 

--- a/flake-modules/ami-images.nix
+++ b/flake-modules/ami-images.nix
@@ -1,0 +1,64 @@
+{ inputs, self, ... }:
+let
+  lib = inputs.nixpkgs.lib;
+  inherit (self) outputs;
+
+  # Central registry of AMI configurations
+  amiConfigs = {
+    aws-base-server = {
+      system = "x86_64-linux";
+      hostConfig = ../hosts/aws-base-server/configuration.nix;
+      extraModules = [];
+    };
+
+    aws-base-server-arm = {
+      system = "aarch64-linux";
+      hostConfig = ../hosts/aws-base-server/configuration.nix;
+      extraModules = [{
+        ec2.efi = true;
+        networking.hostName = lib.mkForce "aws-base-server-arm";
+      }];
+    };
+
+    aws-k8s-node = {
+      system = "x86_64-linux";
+      hostConfig = ../hosts/aws-k8s-node/configuration.nix;
+      extraModules = [];
+    };
+
+    aws-k8s-node-arm = {
+      system = "aarch64-linux";
+      hostConfig = ../hosts/aws-k8s-node/configuration.nix;
+      extraModules = [{
+        ec2.efi = true;
+        networking.hostName = lib.mkForce "aws-k8s-node-arm";
+      }];
+    };
+  };
+
+  mkAmiSystem = _name: cfg:
+    lib.nixosSystem {
+      system = cfg.system;
+
+      specialArgs = {
+        username = "ali";
+        inherit inputs outputs;
+        system = cfg.system;
+      };
+
+      modules = [
+        cfg.hostConfig
+      ] ++ cfg.extraModules;
+    };
+
+  amiSystems = lib.mapAttrs mkAmiSystem amiConfigs;
+in
+{
+  flake.nixosConfigurations = amiSystems;
+
+  perSystem = { system, ... }: {
+    packages = lib.mapAttrs'
+      (name: _: lib.nameValuePair "${name}-ami" amiSystems.${name}.config.system.build.images.amazon)
+      (lib.filterAttrs (_: cfg: cfg.system == system) amiConfigs);
+  };
+}

--- a/flake-modules/dev-shells.nix
+++ b/flake-modules/dev-shells.nix
@@ -14,6 +14,7 @@
           libsecret
           nix-fast-build
           nixos-anywhere
+          uplosi
         ];
       in
       sysPkgs.mkShell {

--- a/flake-modules/nixos-modules.nix
+++ b/flake-modules/nixos-modules.nix
@@ -2,6 +2,7 @@
   flake.nixosModules = {
     # Core modules
     audio-context-suspend = import ../modules/audio-context-suspend.nix;
+    aws = import ../modules/aws;
     base = import ../modules/base;
     desktop = import ../modules/desktop;
     libvirtd = import ../modules/libvirtd;

--- a/hosts/aws-base-server/configuration.nix
+++ b/hosts/aws-base-server/configuration.nix
@@ -1,0 +1,32 @@
+{ modulesPath, lib, ... }:
+{
+  imports = [
+    (modulesPath + "/virtualisation/amazon-image.nix")
+    ../../modules/aws
+    ../../modules/locale
+    ../../modules/servers
+  ];
+
+  modules.aws.enable = true;
+  modules.locale.enable = true;
+
+  modules.servers = {
+    enable = true;
+    openPrometheusFirewallPort = false;
+  };
+
+  networking.hostName = "aws-base-server";
+
+  security.sudo.wheelNeedsPassword = lib.mkForce false;
+
+  system.stateVersion = "25.11";
+
+  users.users.ali = {
+    isNormalUser = true;
+    description = "Alison Jenkins";
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINqNVcWqkNPa04xMXls78lODJ21W43ZX6NlOtFENYUGF"
+    ];
+  };
+}

--- a/hosts/aws-k8s-node/configuration.nix
+++ b/hosts/aws-k8s-node/configuration.nix
@@ -1,0 +1,37 @@
+{ modulesPath, lib, ... }:
+{
+  imports = [
+    (modulesPath + "/virtualisation/amazon-image.nix")
+    ../../modules/aws
+    ../../modules/locale
+    ../../modules/servers
+    ../../app-profiles/k8s-master
+  ];
+
+  modules.aws = {
+    enable = true;
+    rootVolumeSize = 20;
+  };
+
+  modules.locale.enable = true;
+
+  modules.servers = {
+    enable = true;
+    openPrometheusFirewallPort = false;
+  };
+
+  networking.hostName = "aws-k8s-node";
+
+  security.sudo.wheelNeedsPassword = lib.mkForce false;
+
+  system.stateVersion = "25.11";
+
+  users.users.ali = {
+    isNormalUser = true;
+    description = "Alison Jenkins";
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINqNVcWqkNPa04xMXls78lODJ21W43ZX6NlOtFENYUGF"
+    ];
+  };
+}

--- a/hosts/aws-k8s-node/configuration.nix
+++ b/hosts/aws-k8s-node/configuration.nix
@@ -8,10 +8,7 @@
     ../../app-profiles/k8s-master
   ];
 
-  modules.aws = {
-    enable = true;
-    rootVolumeSize = 20;
-  };
+  modules.aws.enable = true;
 
   modules.locale.enable = true;
 

--- a/justfile
+++ b/justfile
@@ -194,11 +194,13 @@ ami-upload hostname region="eu-west-2" bucket="nixos-amis":
 
     echo "Snapshot: $SNAPSHOT_ID"
 
-    # Determine architecture from image-info.json
-    SYSTEM=$(cat "$RESULT/nix-support/image-info.json" | jq -r '.system // "x86_64-linux"')
+    # Read architecture and boot mode from image-info.json
+    IMAGE_INFO="$RESULT/nix-support/image-info.json"
+    SYSTEM=$(jq -r '.system // "x86_64-linux"' "$IMAGE_INFO")
+    BOOT_MODE=$(jq -r '.boot_mode // "uefi"' "$IMAGE_INFO")
     case "$SYSTEM" in
-        aarch64-*) ARCH="arm64"; BOOT_MODE="uefi" ;;
-        *)         ARCH="x86_64"; BOOT_MODE="uefi-preferred" ;;
+        aarch64-*) ARCH="arm64" ;;
+        *)         ARCH="x86_64" ;;
     esac
 
     AMI_NAME="nixos-{{hostname}}-${TIMESTAMP}"

--- a/justfile
+++ b/justfile
@@ -124,6 +124,109 @@ update:
     export NIX_CONFIG="access-tokens = github.com=$(op item get "Github PAT" --fields label=password --reveal --cache)"
     nix flake update --commit-lock-file
 
+# Build an AMI image
+ami-build hostname:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building AMI for {{hostname}}..."
+    nix build ".#{{hostname}}-ami" --print-out-paths
+    echo ""
+    echo "Image info:"
+    cat result/nix-support/image-info.json | jq .
+
+# Upload a built AMI to AWS
+ami-upload hostname region="eu-west-2" bucket="nixos-amis":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    RESULT="./result"
+    if [ ! -d "$RESULT/nix-support" ]; then
+        echo "Error: No built AMI found. Run 'just ami-build {{hostname}}' first."
+        exit 1
+    fi
+
+    # Find the VHD file
+    VHD=$(find "$RESULT" -name "*.vhd" | head -1)
+    if [ -z "$VHD" ]; then
+        echo "Error: No VHD file found in $RESULT"
+        exit 1
+    fi
+
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    S3_KEY="{{hostname}}/${TIMESTAMP}/$(basename "$VHD")"
+
+    echo "Uploading $VHD to s3://{{bucket}}/$S3_KEY..."
+    aws s3 cp "$VHD" "s3://{{bucket}}/$S3_KEY" --region {{region}}
+
+    echo "Importing EBS snapshot..."
+    IMPORT_TASK=$(aws ec2 import-snapshot \
+        --region {{region}} \
+        --description "NixOS AMI {{hostname}} ${TIMESTAMP}" \
+        --disk-container "Format=VHD,UserBucket={S3Bucket={{bucket}},S3Key=$S3_KEY}" \
+        --output json)
+
+    TASK_ID=$(echo "$IMPORT_TASK" | jq -r '.ImportTaskId')
+    echo "Import task: $TASK_ID"
+
+    echo "Waiting for snapshot import to complete..."
+    while true; do
+        STATUS=$(aws ec2 describe-import-snapshot-tasks \
+            --region {{region}} \
+            --import-task-ids "$TASK_ID" \
+            --output json)
+
+        PROGRESS=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.Progress // "0"')
+        STATE=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.Status')
+
+        echo "  Status: $STATE ($PROGRESS%)"
+
+        if [ "$STATE" = "completed" ]; then
+            SNAPSHOT_ID=$(echo "$STATUS" | jq -r '.ImportSnapshotTasks[0].SnapshotTaskDetail.SnapshotId')
+            break
+        elif [ "$STATE" = "error" ]; then
+            echo "Error: Snapshot import failed"
+            echo "$STATUS" | jq '.ImportSnapshotTasks[0].SnapshotTaskDetail'
+            exit 1
+        fi
+
+        sleep 15
+    done
+
+    echo "Snapshot: $SNAPSHOT_ID"
+
+    # Determine architecture from image-info.json
+    SYSTEM=$(cat "$RESULT/nix-support/image-info.json" | jq -r '.system // "x86_64-linux"')
+    case "$SYSTEM" in
+        aarch64-*) ARCH="arm64"; BOOT_MODE="uefi" ;;
+        *)         ARCH="x86_64"; BOOT_MODE="uefi-preferred" ;;
+    esac
+
+    AMI_NAME="nixos-{{hostname}}-${TIMESTAMP}"
+
+    echo "Registering AMI: $AMI_NAME (arch=$ARCH, boot=$BOOT_MODE)..."
+    AMI_ID=$(aws ec2 register-image \
+        --region {{region}} \
+        --name "$AMI_NAME" \
+        --description "NixOS AMI {{hostname}}" \
+        --architecture "$ARCH" \
+        --root-device-name /dev/xvda \
+        --block-device-mappings "DeviceName=/dev/xvda,Ebs={SnapshotId=$SNAPSHOT_ID,VolumeType=gp3}" \
+        --virtualization-type hvm \
+        --boot-mode "$BOOT_MODE" \
+        --ena-support \
+        --output text --query 'ImageId')
+
+    echo ""
+    echo "AMI registered successfully!"
+    echo "  AMI ID: $AMI_ID"
+    echo "  Region: {{region}}"
+    echo "  Name:   $AMI_NAME"
+
+# Build and upload an AMI in one step
+ami hostname region="eu-west-2" bucket="nixos-amis":
+    just ami-build {{hostname}}
+    just ami-upload {{hostname}} {{region}} {{bucket}}
+
 alias b := boot
 alias B := build
 alias s := switch

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -1,0 +1,128 @@
+# AWS/EC2 configuration module
+# Optimized for fast boot and minimal footprint on EC2 instances.
+# SSM agent (from amazon-image.nix) is the primary access method; SSH is opt-in.
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.modules.aws;
+in
+{
+  options.modules.aws = {
+    enable = lib.mkEnableOption "AWS/EC2 configuration";
+
+    enableSSH = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable OpenSSH (disabled by default, SSM agent is primary access)";
+    };
+
+    rootVolumeSize = lib.mkOption {
+      type = lib.types.int;
+      default = 8;
+      description = "Root volume size in GiB";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Image size — applied to the amazon image builder via extendModules
+    image.modules.amazon = {
+      virtualisation.diskSize = cfg.rootVolumeSize * 1024;
+    };
+
+    # Boot speed optimizations
+    boot = {
+      loader.timeout = lib.mkForce 0;
+
+      initrd = {
+        systemd.enable = true;
+        includeDefaultModules = false;
+        kernelModules = [ "nvme" ];
+      };
+
+      kernelParams = [ "quiet" ];
+
+      # Network performance tuning
+      kernel.sysctl = {
+        "net.ipv4.tcp_congestion_control" = "bbr";
+        "net.ipv4.tcp_fastopen" = 3;
+        "net.core.rmem_max" = 16777216;
+        "net.core.wmem_max" = 16777216;
+        "net.ipv4.tcp_rmem" = "4096 1048576 16777216";
+        "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+        "net.core.netdev_max_backlog" = 16384;
+      };
+    };
+
+    # Disable amazon-init (pre-baked AMIs don't need nixos-rebuild on boot)
+    virtualisation.amazon-init.enable = false;
+
+    # Network: use systemd-networkd for faster DHCP
+    networking = {
+      useNetworkd = true;
+      useDHCP = false;
+
+      firewall = {
+        enable = true;
+        allowedTCPPorts = lib.optionals cfg.enableSSH [ 22 ];
+      };
+    };
+
+    systemd.network = {
+      enable = true;
+      wait-online.enable = false;
+
+      networks."10-ec2" = {
+        matchConfig.Name = "en*";
+        networkConfig = {
+          DHCP = "yes";
+          IPv6AcceptRA = true;
+        };
+      };
+    };
+
+    # SSH: opt-in only (mkForce overrides amazon-image.nix default of true)
+    services.openssh = {
+      enable = lib.mkForce cfg.enableSSH;
+      settings = lib.mkIf cfg.enableSSH {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = lib.mkForce "no";
+      };
+    };
+
+    # Minimal packages
+    environment.systemPackages = with pkgs; [
+      awscli2
+      curl
+      htop
+      jq
+      vim
+    ];
+
+    # Nix settings
+    nix = {
+      extraOptions = "experimental-features = nix-command flakes";
+
+      gc = {
+        automatic = true;
+        dates = "weekly";
+        options = "--delete-older-than 30d";
+      };
+
+      settings = {
+        auto-optimise-store = true;
+        trusted-users = [ "root" "@wheel" ];
+      };
+    };
+
+    nixpkgs.config.allowUnfree = true;
+
+    # Use Amazon Time Sync Service
+    services.timesyncd = {
+      enable = true;
+      servers = [ "169.254.169.123" ];
+    };
+
+    # Disable unnecessary services
+    services.fwupd.enable = false;
+  };
+}

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -40,7 +40,11 @@ in
         kernelModules = [ "nvme" ];
       };
 
-      kernelParams = [ "quiet" ];
+      kernelParams = [
+        "quiet"
+        "rd.systemd.show_status=false"
+        "systemd.show_status=false"
+      ];
 
       # Network performance tuning
       kernel.sysctl = {
@@ -63,6 +67,9 @@ in
 
     # Disable amazon-init (pre-baked AMIs don't need nixos-rebuild on boot)
     virtualisation.amazon-init.enable = false;
+
+    # Strip documentation from closure — servers don't need man/info/manual
+    documentation.enable = false;
 
     # Network: use systemd-networkd for faster DHCP
     networking = {
@@ -98,9 +105,9 @@ in
       };
     };
 
-    # Minimal packages
+    # Minimal packages — awscli2 excluded to save ~400 MiB of closure;
+    # install on-demand via `nix run nixpkgs#awscli2` or user profile.
     environment.systemPackages = with pkgs; [
-      awscli2
       curl
       htop
       jq
@@ -131,7 +138,13 @@ in
       servers = [ "169.254.169.123" ];
     };
 
+    # Cap journal size to reduce I/O from rotation
+    services.journald.extraConfig = "SystemMaxUse=50M";
+
     # Disable unnecessary services
     services.fwupd.enable = false;
+
+    systemd.services.systemd-journal-catalog-update.enable = false;
+    systemd.services.systemd-update-utmp.enable = false;
   };
 }

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -65,8 +65,44 @@ in
       options = [ "noatime" "lazytime" "commit=60" "data=writeback" ];
     };
 
-    # Disable amazon-init (pre-baked AMIs don't need nixos-rebuild on boot)
+    # Disable amazon-init (pre-baked AMIs don't need nixos-rebuild on boot);
+    # cloud-init handles instance provisioning instead.
     virtualisation.amazon-init.enable = false;
+
+    # Cloud-init for EC2 instance provisioning (SSH keys, hostname, user-data scripts)
+    services.cloud-init = {
+      enable = true;
+      network.enable = false; # We manage networking via systemd-networkd above
+
+      settings = {
+        datasource_list = [ "Ec2" ];
+        datasource.Ec2.metadata_urls = [ "http://169.254.169.254" ];
+
+        # Only run modules relevant to pre-baked AMIs
+        cloud_init_modules = [
+          "seed_random"
+          "growpart"
+          "resizefs"
+          "update_hostname"
+          "users-groups"
+          "ssh"
+        ];
+
+        cloud_config_modules = [
+          "ssh-import-id"
+          "set-passwords"
+          "runcmd"
+        ];
+
+        cloud_final_modules = [
+          "scripts-per-once"
+          "scripts-per-boot"
+          "scripts-per-instance"
+          "scripts-user"
+          "final-message"
+        ];
+      };
+    };
 
     # Strip documentation from closure — servers don't need man/info/manual
     documentation.enable = false;

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -16,15 +16,17 @@ in
     };
 
     rootVolumeSize = lib.mkOption {
-      type = lib.types.int;
-      default = 8;
-      description = "Root volume size in GiB";
+      type = lib.types.either (lib.types.enum [ "auto" ]) lib.types.int;
+      default = "auto";
+      description = "Root volume size in GiB, or \"auto\" to fit the closure with minimal headroom. The partition auto-grows to the EBS volume size at boot.";
     };
   };
 
   config = lib.mkIf cfg.enable {
-    # Image size — applied to the amazon image builder via extendModules
-    image.modules.amazon = {
+    # Image size — applied to the amazon image builder via extendModules.
+    # "auto" lets make-disk-image size the image to fit the closure;
+    # the partition grows to the EBS volume at boot via growPartition.
+    image.modules.amazon = lib.mkIf (cfg.rootVolumeSize != "auto") {
       virtualisation.diskSize = cfg.rootVolumeSize * 1024;
     };
 

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -71,6 +71,17 @@ in
     # Strip documentation from closure — servers don't need man/info/manual
     documentation.enable = false;
 
+    # Strip desktop packages from closure
+    xdg.icons.enable = false;
+    xdg.mime.enable = false;
+    xdg.sounds.enable = false;
+    fonts.fontconfig.enable = false;
+    programs.command-not-found.enable = false;
+    environment.defaultPackages = lib.mkForce [];
+
+    # Use tmpfs for /tmp to avoid disk I/O for temp files
+    boot.tmp.useTmpfs = true;
+
     # Network: use systemd-networkd for faster DHCP
     networking = {
       useNetworkd = true;

--- a/modules/aws/default.nix
+++ b/modules/aws/default.nix
@@ -54,6 +54,13 @@ in
       };
     };
 
+    # Root filesystem tuning — reduce write I/O during boot when NixOS
+    # reads hundreds of store paths. Safe for immutable infrastructure
+    # where runtime state lives in EBS snapshots / S3 / external DBs.
+    fileSystems."/" = lib.mkDefault {
+      options = [ "noatime" "lazytime" "commit=60" "data=writeback" ];
+    };
+
     # Disable amazon-init (pre-baked AMIs don't need nixos-rebuild on boot)
     virtualisation.amazon-init.enable = false;
 


### PR DESCRIPTION
## Overview

Adds full AWS AMI build and upload support to the flake, including a reusable NixOS module for EC2 configuration, two host profiles (base server and K8s node), a flake-parts module that exposes AMI build targets as `nix build` packages, and a GitHub Actions CI pipeline that publishes the images automatically on push to main.

## Changes

- **`modules/aws/default.nix`** — New reusable NixOS module (`modules.aws`) that configures an EC2 instance for minimal footprint and fast boot:
  - UEFI boot with a 0-second bootloader timeout
  - systemd initrd with only the `nvme` kernel module included
  - systemd-networkd with DHCP on `en*` interfaces (replaces DHCP services)
  - cloud-init (Ec2 datasource only) for SSH key injection, hostname, growpart/resizefs, and user-data scripts; `amazon-init` is disabled
  - `noatime`/`lazytime`/`commit=60`/`data=writeback` ext4 mount options to reduce boot I/O
  - tmpfs for `/tmp`
  - Network performance tuning via `sysctl` (BBR, TCP fast open, larger socket buffers)
  - Documentation, desktop packages, fonts, icons, and sounds stripped from closure
  - SSH opt-in via `modules.aws.enableSSH` (SSM agent is the primary access method)
  - Auto-sized disk images by default (`modules.aws.rootVolumeSize = "auto"`) with `growPartition` at boot
  - Journal capped at 50 MiB; `fwupd`, `systemd-journal-catalog-update`, and `systemd-update-utmp` disabled
  - Weekly Nix GC with 30-day retention; Nix store auto-optimised

- **`hosts/aws-base-server/configuration.nix`** — Minimal general-purpose NixOS server AMI using `modules.aws`, `modules.locale`, and `modules.servers`.

- **`hosts/aws-k8s-node/configuration.nix`** — K8s node AMI that extends the base server with `app-profiles/k8s-master`.

- **`flake-modules/ami-images.nix`** — flake-parts module that:
  - Defines four AMI configurations in a central registry: `aws-base-server`, `aws-base-server-arm`, `aws-k8s-node`, `aws-k8s-node-arm`
  - Builds each as a `nixosConfiguration` with `ec2.efi = true` for UEFI/NitroTPM support
  - Exposes per-system `packages.<name>-ami` pointing to `system.build.images.amazon` for `nix build` consumption

- **`flake-modules/nixos-modules.nix`** — Exports `flake.nixosModules.aws` so the module is available to external consumers.

- **`flake-modules/dev-shells.nix`** — Adds `uplosi` (cloud image uploader) to the default dev shell.

- **`justfile`** — Adds `ami-build <hostname>` and `ami-upload <hostname> [region] [bucket]` recipes for local development and ad-hoc uploads.

- **`.github/workflows/ami-build-and-upload.yaml`** — CI pipeline that:
  - Triggers on push to `main` when AMI-related paths change, or via `workflow_dispatch` with selectable hostname, region, and retention count
  - Builds the AMI with `nix build` (via `cachix watch-exec` for binary cache population)
  - Uploads the resulting VHD to S3 (`ajj-ami-builds` bucket in `eu-west-2`)
  - Imports an EBS snapshot via `ec2:ImportSnapshot`, polling until complete
  - Registers the snapshot as an AMI with architecture and boot mode read from `image-info.json`
  - Tags both the AMI and snapshot with hostname, git SHA, and build timestamp
  - Cleans up AMIs and S3 uploads beyond a configurable retention count (default: 3)
  - Authenticates to AWS via GitHub OIDC (no long-lived credentials)

## Context

The pipeline uses OIDC federation so no static AWS credentials are stored in GitHub secrets — only the IAM role ARN is required. ARM AMI variants (`aws-base-server-arm`, `aws-k8s-node-arm`) are defined in the registry but excluded from the CI matrix until ARM runners are available.