### PR TITLE
Fix IAM role ARN in AMI workflow

### DIFF
--- a/.github/workflows/ami-build-and-upload.yaml
+++ b/.github/workflows/ami-build-and-upload.yaml
@@ -16,7 +16,7 @@
 #      - Trusts vmie.amazonaws.com
 #      - S3 read on the bucket + EC2 snapshot permissions
 #   4. S3 bucket "ajj-ami-builds" in eu-west-2
-#   5. GitHub secret AWS_IAM_ROLE_ARN set to the role ARN
+#   5. IAM role ARN is hardcoded in the workflow
 
 name: Build and Upload AMIs
 
@@ -148,7 +148,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::918821718107:role/gha-nix-config-ami
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload VHD to S3


### PR DESCRIPTION
## Summary
- Hardcode the IAM role ARN in the AMI build workflow instead of referencing a missing `AWS_IAM_ROLE_ARN` secret, which caused credential loading to fail

## Test plan
- [ ] Trigger the AMI build workflow manually and verify AWS credentials load successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)