### PR TITLE
Fix: install AWS CLI in AMI workflow

### DIFF
--- a/.github/workflows/ami-build-and-upload.yaml
+++ b/.github/workflows/ami-build-and-upload.yaml
@@ -145,6 +145,9 @@ jobs:
           echo "boot_mode=$BOOT_MODE" >> "$GITHUB_OUTPUT"
           echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
 
+      - name: Install AWS CLI
+        run: nix profile install nixpkgs#awscli2
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- Install AWS CLI via `nix profile install nixpkgs#awscli2` since the `nothing-but-nix` action strips pre-installed tools from the runner

## Test plan
- [ ] Trigger AMI build workflow and verify `aws` commands succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)