### PR TITLE
Add NixOS AMI build pipeline and Rust flake templates

### DIFF
--- a/.github/workflows/ami-build-and-upload.yaml
+++ b/.github/workflows/ami-build-and-upload.yaml
@@ -9,13 +9,13 @@
 #   2. IAM Role with trust policy allowing:
 #      - Federated principal: the OIDC provider ARN
 #      - Condition: token.actions.githubusercontent.com:sub like repo:alisonjenkins/nix-config:*
-#      - Permissions: s3:{PutObject,ListBucket,DeleteObject} on ajj-ami-builds bucket;
+#      - Permissions: s3:{PutObject,ListBucket,DeleteObject} on ajj-ami-builds-eu-west-1 bucket;
 #        ec2:{ImportSnapshot,DescribeImportSnapshotTasks,RegisterImage,DeregisterImage,
 #             DescribeImages,DescribeSnapshots,DeleteSnapshot,CreateTags}
 #   3. vmimport service role (required by ec2:ImportSnapshot):
 #      - Trusts vmie.amazonaws.com
 #      - S3 read on the bucket + EC2 snapshot permissions
-#   4. S3 bucket "ajj-ami-builds" in eu-west-1
+#   4. S3 bucket "ajj-ami-builds-eu-west-1" in eu-west-1
 #   5. IAM role ARN is hardcoded in the workflow
 
 name: Build and Upload AMIs
@@ -95,7 +95,7 @@ jobs:
     env:
       AWS_REGION: ${{ needs.prepare.outputs.region }}
       RETENTION_COUNT: ${{ needs.prepare.outputs.retention_count }}
-      S3_BUCKET: ajj-ami-builds
+      S3_BUCKET: ajj-ami-builds-eu-west-1
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Overview

This branch adds a full NixOS AMI build and publishing pipeline for AWS EC2, plus improvements to the existing Rust flake template and a new Rust Lambda template.

## Changes

### AWS/EC2 AMI support

- Add a reusable `modules.aws` NixOS module with boot speed optimisations (systemd initrd, `timeout=0`, quiet boot, BBR TCP tuning, minimal package set), SSM-first access (SSH opt-in), cloud-init for EC2 provisioning (SSH key injection, hostname, user-data, partition grow/resize), and opt-in UEFI boot for all architectures
- Add two host configurations — `aws-base-server` (minimal server with Prometheus exporters) and `aws-k8s-node` (extends base with k8s-master app-profile and a 20 GiB root volume)
- Add a `flake-modules/ami-images.nix` flake-parts module that builds `nixosConfigurations` for both hosts in x86_64 and aarch64, exposing `system.build.images.amazon` as packages (e.g. `nix build .#aws-base-server-ami`)
- Tune AMI image size and I/O: auto-sized images (fit closure, not fixed 8 GiB), ext4 `noatime`/`lazytime`/`commit=60`/`data=writeback` mount options, tmpfs `/tmp`, stripped desktop packages and documentation, capped systemd journal at 50 MiB
- Add `ami-build`, `ami-upload`, and `ami` targets to the justfile; add `uplosi` to the dev-shell as an alternative uploader

### GitHub Actions CI for AMI publishing

- Add `.github/workflows/ami-build-and-upload.yaml` that builds a VHD via Nix, uploads to S3, imports an EBS snapshot, registers an AMI (reading `boot_mode` from `image-info.json`), and prunes old AMIs beyond a configurable retention count (default 3)
- Triggers on push to `main` when AMI-related files change, or manually via `workflow_dispatch` with selectable AMI, region, and retention inputs
- Authenticates via GitHub OIDC (no long-lived AWS secrets); installs AWS CLI through Nix since the `nothing-but-nix` action strips the runner environment

### Rust flake templates

- Overhaul the existing `rust` template: replace naersk with crane + rust-overlay, add clippy/fmt/doc/nextest checks runnable via `nix flake check`, add distroless container image outputs, and add a GitHub Actions workflow for CI checks and ECR image pushes on merge to main
- Add a new `rust-lambda` template for AWS Lambda functions: crane + rust-overlay build, `cargo-lambda` in the devshell for local emulation, distroless container image for Lambda container deployments, a justfile with `build`/`container`/`watch`/`invoke`/`deploy-zip`/`push` tasks, and a CI workflow for ECR pushes; registered in `flake-modules/templates.nix` as `#rust-lambda`

## Context

The AMI pipeline targets pre-baked, immutable AMIs where cloud-init handles instance-level provisioning at launch time (SSH keys, hostname, user-data scripts) while the NixOS system configuration is baked in at build time. `amazon-init` (which would run `nixos-rebuild` on every boot) is disabled. The Rust templates are aligned with the same Nix toolchain choices used in the AMI workflow, making them consistent reference points for new projects in this ecosystem.