### PR TITLE
fix(base): drop mkDefault from trusted-users to prevent wheel exclusion

### DIFF
--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -264,7 +264,7 @@ in
           download-buffer-size = 268435456; # 256 MiB
           eval-cache = true;
           max-jobs = "auto";
-          trusted-users = lib.mkDefault [ "root" "@wheel" ];
+          trusted-users = [ "root" "@wheel" ];
 
           substituters = [
             "https://ajenkins-public.cachix.org"


### PR DESCRIPTION
## Summary
- Removes `lib.mkDefault` from `nix.settings.trusted-users` in the base module
- `mkDefault` (priority 1000) was silently overridden by the NixOS nix module's own `trusted-users = [ "root" ]` (priority 100), discarding `@wheel`
- This caused non-root wheel users to see `warning: ignoring untrusted substituter` for cachix substituters

## Test plan
- [ ] Verify `nix eval ".#nixosConfigurations.ali-desktop.config.nix.settings.trusted-users"` includes `@wheel`
- [ ] After `just switch`, confirm `/etc/nix/nix.conf` contains `trusted-users = root @wheel`
- [ ] Confirm cachix substituter warnings no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)