### PR TITLE
fix: disable ceph support in qemu_full on ali-desktop

### DIFF
--- a/hosts/ali-desktop/configuration.nix
+++ b/hosts/ali-desktop/configuration.nix
@@ -207,7 +207,7 @@
       protontricks
       protonvpn-gui
       qbittorrent
-      qemu_full
+      (qemu_full.override { cephSupport = false; })
       radeontop
       rio
       s-tui


### PR DESCRIPTION
## Summary
- Overrides `qemu_full` with `cephSupport = false` on ali-desktop
- The `pythonPackagesExtensions` overlay (disabling `aiohttp` tests etc.) invalidates binary cache hashes for ceph's Python dependency closure, forcing ceph-19.2.3 (~20 min), arrow-cpp (~3 min), and qemu (~9 min) to compile from source every build
- This single change should save ~32 min from the desktop CI build (~50 min → ~18 min)

## Test plan
- [ ] Verify `nix build .#nixosConfigurations.ali-desktop.config.system.build.toplevel` succeeds
- [ ] Confirm ceph/arrow-cpp/qemu are no longer in the `--dry-run` build list
- [ ] Check CI build time drops significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)