### PR TITLE
ci(build-and-cache): point build-desktops at public niks3 URL

### DIFF
--- a/.github/workflows/build-and-cache.yaml
+++ b/.github/workflows/build-and-cache.yaml
@@ -155,9 +155,10 @@ jobs:
       contents: read
       actions: read
     env:
-      # Use cluster-internal service URL — these runners are pods in the k3s cluster,
-      # so the external URL (api.nixcache.org → public IP) causes hairpin NAT timeouts.
-      NIKS3_SERVER_URL: http://niks3.niks3.svc.cluster.local
+      # home-nix-builder-amd64 runs in home-cluster-1; niks3 lives in aws-k3s,
+      # so the cluster-internal service DNS (niks3.niks3.svc.cluster.local) does
+      # not resolve. Use the public ingress URL.
+      NIKS3_SERVER_URL: https://api.nixcache.org
       # Host nix daemon post-build-hook writes to /var/tmp/niks3-queue
       NIKS3_QUEUE: /var/tmp/niks3-queue
     steps:


### PR DESCRIPTION
## Summary
- `build-desktops` runs on `home-nix-builder-amd64` (home-cluster-1), but niks3 lives in aws-k3s. Cluster-internal DNS `niks3.niks3.svc.cluster.local` does not resolve cross-cluster, so cache pushes errored with `no such host` (e.g. https://github.com/alisonjenkins/nix-config/actions/runs/25151659416/job/73723445428).
- Switched `NIKS3_SERVER_URL` for the `build-desktops` job to `https://api.nixcache.org` (the niks3 ingress) so pushes succeed.
- `build-arm64` left as-is — that job runs on `aws-nix-builder-arm64` (same cluster as niks3) and is currently gated on `if: false` anyway.

## Test plan
- [ ] Trigger workflow on `main`; confirm `build-desktops` push step shows `[drainer] Batch N: done` and no DNS errors.
- [ ] Verify pushed paths land in cache (`curl -I https://api.nixcache.org/<hash>.narinfo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)