### PR TITLE
fix(darwin): pass --force-cleanup to brew bundle activation

### DIFF
--- a/flake-modules/hosts/ali-mba/default.nix
+++ b/flake-modules/hosts/ali-mba/default.nix
@@ -278,6 +278,10 @@ in {
             autoUpdate = true;
             cleanup = "uninstall";
             upgrade = true;
+            # Homebrew 4.x refuses `brew bundle --cleanup` non-interactively
+            # without --force/--force-cleanup/$HOMEBREW_ASK. nix-darwin doesn't
+            # emit it, so pass it ourselves.
+            extraFlags = [ "--force-cleanup" ];
           };
 
           taps = [

--- a/flake-modules/hosts/ali-work-laptop-macos/default.nix
+++ b/flake-modules/hosts/ali-work-laptop-macos/default.nix
@@ -270,6 +270,10 @@ in {
             autoUpdate = true;
             cleanup = "uninstall";
             upgrade = true;
+            # Homebrew 4.x refuses `brew bundle --cleanup` non-interactively
+            # without --force/--force-cleanup/$HOMEBREW_ASK. nix-darwin doesn't
+            # emit it, so pass it ourselves.
+            extraFlags = [ "--force-cleanup" ];
           };
 
           taps = [


### PR DESCRIPTION
Homebrew 4.x refuses `brew bundle --cleanup` non-interactively without --force/--force-cleanup/$HOMEBREW_ASK. nix-darwin emits --cleanup (from onActivation.cleanup = "uninstall") but never the force flag, so `just switch` fails activation. Add extraFlags = [ "--force-cleanup" ] on both Darwin hosts.