### PR TITLE
feat(swayidle): power displays off after 30 min idle

### DIFF
--- a/home/home-common.nix
+++ b/home/home-common.nix
@@ -20,6 +20,11 @@
 
   _module.args.enableDifftastic = lib.mkDefault true;
 
+  # Total idle seconds before swayidle powers the displays off (DPMS) via niri.
+  # Default 30 min for all niri hosts; a host can override via extraSpecialArgs,
+  # or set to null to disable. See home/programs/linux-only/swayidle.
+  _module.args.screenOffTimeoutSeconds = lib.mkDefault 1800;
+
   home = {
     inherit username;
     homeDirectory = lib.mkForce (

--- a/home/programs/linux-only/swayidle/default.nix
+++ b/home/programs/linux-only/swayidle/default.nix
@@ -5,7 +5,10 @@
   # Total idle seconds before the displays are powered off (DPMS) via niri.
   # Fires independently of the 900s lock timeout, so on niri hosts a locked,
   # idle screen no longer stays lit indefinitely. Set to null to disable.
-  screenOffTimeoutSeconds ? 1800,
+  # Default lives solely in home/home-common.nix
+  # (`_module.args.screenOffTimeoutSeconds`) — the module system resolves this
+  # arg from _module.args, so a function-default here would be dead code.
+  screenOffTimeoutSeconds,
   ...
 }: {
   home.packages = with pkgs; [

--- a/home/programs/linux-only/swayidle/default.nix
+++ b/home/programs/linux-only/swayidle/default.nix
@@ -1,6 +1,11 @@
 {
   bluetoothHeadsetMac ? "",
+  lib,
   pkgs,
+  # Total idle seconds before the displays are powered off (DPMS) via niri.
+  # Fires independently of the 900s lock timeout, so on niri hosts a locked,
+  # idle screen no longer stays lit indefinitely. Set to null to disable.
+  screenOffTimeoutSeconds ? 1800,
   ...
 }: {
   home.packages = with pkgs; [
@@ -27,6 +32,12 @@
 
     timeouts = [
       { timeout = 900; command = "${pkgs.lock-session}/bin/lock-session ${toString idleLockGracePeriodSeconds} ${toString lockFadeInSeconds}"; }
+    ] ++ lib.optionals (screenOffTimeoutSeconds != null) [
+      {
+        timeout = screenOffTimeoutSeconds;
+        command = "${pkgs.niri}/bin/niri msg action power-off-monitors";
+        resumeCommand = "${pkgs.niri}/bin/niri msg action power-on-monitors";
+      }
     ];
   };
 }


### PR DESCRIPTION
## Overview

Fixes locked/idle screens staying powered on indefinitely on niri hosts — observed to persist for days, wasting power and risking panel burn-in. Adds a configurable screen-off timeout to the swayidle home module so monitors are powered down independently of the existing lock timeout.

## Changes

- **`home/programs/linux-only/swayidle/default.nix`**: Adds a `screenOffTimeoutSeconds` function parameter. When non-null, appends a swayidle `timeout` entry that runs `niri msg action power-off-monitors` after the specified interval, with a matching `resumeCommand` of `niri msg action power-on-monitors`. Uses `${pkgs.niri}` consistent with the existing precedent in `pkgs/suspend-scripts/default.nix`. The screen-off timeout is independent of the 900s lock — swaylock continues running while monitors are off.
- **`home/home-common.nix`**: Adds `_module.args.screenOffTimeoutSeconds = lib.mkDefault 1800` to default all niri hosts to 30 minutes. Follows the repo's existing idiom for defaulting custom module args (mirrors `azureDevopsRsaKey`). Hosts can override via `extraSpecialArgs` or pass `null` to disable.

## Context

The active idle daemon on niri hosts is swayidle. Prior to this change it only had a single 900s timeout to invoke swaylock, with no display power management configured. Niri delegates all idle/DPMS handling to swayidle, so without an explicit timeout the displays stay on indefinitely after the screen locks.

## Testing

- `nix build .#nixosConfigurations.ali-desktop.config.system.build.toplevel` — succeeds
- `nix eval .#homeConfigurations."ali@ali-desktop".config.services.swayidle.timeouts` — emits both the 900s lock entry and the 1800s `power-off-monitors` entry with a `power-on-monitors` resumeCommand

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)