### PR TITLE
fix(arkana): re-point ars_nouveau to Modrinth (CurseForge link-rot)

### DIFF
--- a/pkgs/create-arkana-aeronautics-server/arkana-mods-extras.nix
+++ b/pkgs/create-arkana-aeronautics-server/arkana-mods-extras.nix
@@ -283,7 +283,11 @@
       required      = true;
       filename      = "ars_nouveau-1.21.1-5.11.3.jar";
       jar = fetchurl {
-        url    = "https://mediafilez.forgecdn.net/files/7764/018/ars_nouveau-1.21.1-5.11.3.jar";
+        # Re-pointed from CurseForge to Modrinth: the CF mediafilez file
+        # (fileID 7764018) now 403s for everyone (CF link-rot), breaking the
+        # build whenever the jar is GC'd. Byte-identical jar (same sha256).
+        # projectID/fileID above are kept for the client-zip CF manifest entry.
+        url    = "https://cdn.modrinth.com/data/TKB6INcv/versions/BmGGrC9A/ars_nouveau-1.21.1-5.11.3.jar";
         name   = "ars_nouveau-1.21.1-5.11.3.jar";
         sha256 = "0dxvvxa03fznyv5ixl4sml1wwmnwy2yqx0f6sq2f5sspd5ay3xci";
       };


### PR DESCRIPTION
The pinned CurseForge file for `ars_nouveau-1.21.1-5.11.3` (fileID 7764018) now **403s for everyone** (CF link-rot), breaking `nix build .#minecraft-arkana-aeronautics-image` whenever the jar is GC'd. Re-points the fetchurl to **Modrinth's CDN** for the **byte-identical** jar (same sha256 — no dependent rebuilds). `projectID`/`fileID` kept for the client-zip CF manifest.

Verified: the server image now builds. Surfaced while productionizing the NeoVelocity forwarding (#141); unrelated pre-existing rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)