### PR TITLE
feat(ami): pre-bake arkana minecraft image into Karpenter worker AMI

### DIFF
--- a/.github/workflows/ami-build-and-upload.yaml
+++ b/.github/workflows/ami-build-and-upload.yaml
@@ -28,6 +28,7 @@ on:
     paths:
       - '.github/workflows/ami-build-and-upload.yaml'
       - 'flake-modules/ami-images.nix'
+      - 'flake-modules/karpenter-prepull-images.json'
       - 'modules/aws/**'
       - 'modules/servers/**'
       - 'modules/locale/**'

--- a/flake-modules/karpenter-prepull-images.json
+++ b/flake-modules/karpenter-prepull-images.json
@@ -126,5 +126,21 @@
     "imageDigest": "sha256:a911876a5d1f30e0087aa7458af668e1df8baae459d8bb38063213e9bf450ef2",
     "hash": "sha256-nRd+L+svUYDZ1tIeFthfTh7SCsdAMk90aGQjZQf+0IA="
   }
+,
+  {
+    "imageName": "ghcr.io/alisonjenkins/create-arkana-aeronautics-server",
+    "imageTag": "v1.5-aero-1.2.1-62",
+    "arch": "amd64",
+    "imageDigest": "sha256:bbf8e2ef3442c22d0421add07983047056089ee2be2cb3071d48e9a23db32253",
+    "hash": "sha256-tkmWx9uspB9a8nNRQCb+LqYaUuXNB3Hm8xDZEgH+6VY="
+  }
+,
+  {
+    "imageName": "ghcr.io/alisonjenkins/create-arkana-aeronautics-server",
+    "imageTag": "v1.5-aero-1.2.1-62",
+    "arch": "arm64",
+    "imageDigest": "sha256:bbf8e2ef3442c22d0421add07983047056089ee2be2cb3071d48e9a23db32253",
+    "hash": "sha256-En3LuESeczx7KN2O4p+g5DfjTT2DE6hRTWrbLuR9Yf4="
+  }
 
 ]


### PR DESCRIPTION
## What

Add `ghcr.io/alisonjenkins/create-arkana-aeronautics-server:v1.5-aero-1.2.1-62` (amd64 + arm64) to `flake-modules/karpenter-prepull-images.json`, so the AMI build bakes it into the worker node's containerd store.

## Why

Profiling the minecraft scale-from-zero cold start, the arkana image pull (~863 MB compressed) was the largest controllable slice — 27–70s on a fresh spot node, variable with ghcr. Pre-baking it (same mechanism already used for cilium / ebs-csi / etc.) means it's present in containerd at boot, so the backend pod skips the pull entirely.

Other cold-start costs are AWS-fixed (spot instance-start) or already pre-baked (cilium, CSI). This is the one big lever.

## Notes

- Index digest `sha256:bbf8e2ef…` shared across both arch entries; per-arch FOD hashes from `nix-prefetch-docker`, matching the existing entry style.
- Adds ~2.5 GB uncompressed to the worker root image (100Gi EC2NodeClass root — ample).
- New AMI is built + uploaded by the `ami-build-and-upload` workflow; the minecraft EC2NodeClass `amiSelectorTerms` (`nixos-aws-karpenter-node-{arm,amd64}-*`) auto-selects the newest.
- Bump this tag in lockstep whenever the arkana server image is re-tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)