### PR TITLE
feat: self-maintaining nix store across NixOS, macOS, and home-manager hosts

### DIFF
--- a/flake-modules/darwin-modules.nix
+++ b/flake-modules/darwin-modules.nix
@@ -1,5 +1,6 @@
 { ... }: {
   flake.darwinModules = {
+    darwin-nix-maintenance = import ../modules/darwin-nix-maintenance;
     niks3-cache-push = import ../modules/niks3-cache-push/darwin.nix;
     github-actions-runner = import ../modules/github-actions-runner/darwin.nix;
   };

--- a/flake-modules/home-modules.nix
+++ b/flake-modules/home-modules.nix
@@ -20,6 +20,15 @@
           trusted-users = [ "root" "@wheel" ];
           experimental-features = "nix-command flakes";
         };
+        # Periodic GC via a systemd user timer running nix-collect-garbage.
+        # Note: on this multi-user nix install a *user* config can't set
+        # daemon-level min-free/max-free or auto-optimise-store, so this is
+        # periodic GC only (no free-space-triggered GC / store optimise).
+        gc = {
+          automatic = true;
+          frequency = "weekly";
+          options = "--delete-older-than 60d";
+        };
       };
     };
     steam-deck-config = { pkgs, ... }: {
@@ -27,6 +36,13 @@
         package = pkgs.nix;
         settings = {
           trusted-users = [ "root" "@wheel" ];
+        };
+        # Periodic GC via a systemd user timer (see ali-desktop-arch-config
+        # for the multi-user-daemon caveat).
+        gc = {
+          automatic = true;
+          frequency = "weekly";
+          options = "--delete-older-than 60d";
         };
       };
     };

--- a/flake-modules/hosts/ali-mba/default.nix
+++ b/flake-modules/hosts/ali-mba/default.nix
@@ -463,6 +463,7 @@ in {
       })
 
       inputs.sops-nix.darwinModules.sops
+      self.darwinModules.darwin-nix-maintenance
       self.darwinModules.niks3-cache-push
       self.darwinModules.github-actions-runner
       ({ config, ... }: {

--- a/flake-modules/hosts/ali-mba/default.nix
+++ b/flake-modules/hosts/ali-mba/default.nix
@@ -302,9 +302,8 @@ in {
             #enable = true;
           #};
 
-          #gc = {
-            #automatic = true;
-          #};
+          # GC / optimise / free-space settings live in
+          # self.darwinModules.darwin-nix-maintenance.
 
           linux-builder = {
             enable = true;
@@ -362,10 +361,6 @@ in {
               };
             };
           };
-
-          # optimise = {
-          #   enable = true;
-          # };
 
           settings = {
             # nix.linux-builder auto-populates `builders` and `extra-platforms`,

--- a/flake-modules/hosts/ali-work-laptop-macos/default.nix
+++ b/flake-modules/hosts/ali-work-laptop-macos/default.nix
@@ -293,9 +293,8 @@ in {
             #enable = true;
           #};
 
-          #gc = {
-            #automatic = true;
-          #};
+          # GC / optimise / free-space settings live in
+          # self.darwinModules.darwin-nix-maintenance.
 
           # run: "nix run 'nixpkgs#darwin.linux-builder'" before enabling
           # linux-builder = {
@@ -313,10 +312,6 @@ in {
           #       cores = 8;
           #     };
           #   };
-          # };
-
-          # optimise = {
-          #   enable = true;
           # };
 
           settings = {

--- a/flake-modules/hosts/ali-work-laptop-macos/default.nix
+++ b/flake-modules/hosts/ali-work-laptop-macos/default.nix
@@ -51,6 +51,7 @@ in {
   flake.darwinConfigurations."${hostnames.civica}" = inputs.darwin.lib.darwinSystem {
     system = darwinSystem;
     modules = [
+      self.darwinModules.darwin-nix-maintenance
       # Host-specific configuration (inlined from configuration.nix)
       ({ pkgs, inputs, outputs, username, hostname, ... }: {
         environment = {

--- a/flake-modules/hosts/home-only/default.nix
+++ b/flake-modules/hosts/home-only/default.nix
@@ -15,7 +15,6 @@ let
         self.overlays.master-packages
         self.overlays.unstable-packages
         self.overlays.zk
-        self.overlays.qbittorrent
         inputs.nur.overlays.default
         inputs.fenix.overlays.default
       ]

--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -317,8 +317,21 @@ in
           options = lib.mkDefault "--delete-older-than 60d";
         };
 
+        # Scheduled hardlink dedup sweep, complementing the per-build
+        # auto-optimise-store below.
+        optimise = {
+          automatic = lib.mkDefault true;
+          dates = lib.mkDefault [ "weekly" ];
+        };
+
         settings = {
-          auto-optimise-store = lib.mkDefault false;
+          auto-optimise-store = lib.mkDefault true;
+          # Free-space-triggered GC: the daemon GCs mid-build when free space
+          # drops below min-free, freeing until max-free is available. This is
+          # the safety net that stops the store filling the disk between the
+          # scheduled weekly GC runs above.
+          min-free = lib.mkDefault (5 * 1024 * 1024 * 1024); # 5 GiB
+          max-free = lib.mkDefault (20 * 1024 * 1024 * 1024); # 20 GiB
           cores = lib.mkDefault 0;
           experimental-features = lib.mkDefault [ "nix-command" "flakes" "ca-derivations" ];
           download-buffer-size = lib.mkDefault 268435456; # 256 MiB

--- a/modules/darwin-nix-maintenance/default.nix
+++ b/modules/darwin-nix-maintenance/default.nix
@@ -1,0 +1,41 @@
+# Self-maintaining Nix store for nix-darwin hosts.
+#
+# Mirrors the NixOS maintenance set in modules/base, but using nix-darwin's
+# option shapes (GC/optimise schedules are launchd `interval` attrsets, not
+# systemd `dates` strings). Kept as a separate darwin module rather than
+# branching modules/base on isDarwin, per the repo's cross-platform split.
+#
+# All values are mkDefault so a host can override per-disk (e.g. a larger
+# min-free on a machine that does big builds).
+{ lib, ... }:
+{
+  nix.gc = {
+    automatic = lib.mkDefault true;
+    interval = lib.mkDefault {
+      Weekday = 0;
+      Hour = 3;
+      Minute = 15;
+    };
+    options = lib.mkDefault "--delete-older-than 60d";
+  };
+
+  # Scheduled hardlink dedup sweep, complementing per-build
+  # auto-optimise-store below.
+  nix.optimise = {
+    automatic = lib.mkDefault true;
+    interval = lib.mkDefault {
+      Weekday = 0;
+      Hour = 4;
+      Minute = 15;
+    };
+  };
+
+  nix.settings = {
+    auto-optimise-store = lib.mkDefault true;
+    # Free-space-triggered GC: the daemon GCs mid-build when free space drops
+    # below min-free, freeing until max-free is available — the safety net
+    # that stops the store filling the disk between scheduled GC runs.
+    min-free = lib.mkDefault (5 * 1024 * 1024 * 1024); # 5 GiB
+    max-free = lib.mkDefault (20 * 1024 * 1024 * 1024); # 20 GiB
+  };
+}


### PR DESCRIPTION
## Context

The Nix store periodically fills the disk it lives on. Maintenance was time-based only and incomplete:

- **NixOS**: weekly GC (`--delete-older-than 60d`), `auto-optimise-store=false`, no free-space-triggered GC (except `home-k8s-master-1`). Time-based GC can't stop a fill **mid-build** between runs.
- **Darwin** (`ali-mba`, `ali-work-laptop-macos`): `nix.gc`/`nix.optimise` commented out — no auto maintenance at all.
- **home-manager-only** (`ali` Arch, `deck` SteamOS): nothing — manual `nix-collect-garbage` only.

Core fix: **free-space-triggered GC** (`min-free`/`max-free`) — the daemon GCs automatically when free space drops during a build — plus GC + store dedup on Darwin and periodic GC timers on the home-only Linux hosts.

Decisions: optimise = both (per-build `auto-optimise-store` + scheduled weekly sweep); free-space GC `min-free 5 GiB` / `max-free 20 GiB` (overridable); retention kept at 60d.

## Changes

- **`feat(base)`** — NixOS: free-space GC (5/20 GiB), `auto-optimise-store=true`, weekly scheduled optimise. All `mkDefault`, so `home-k8s-master-1` mkForce + `hetzner`/`aws` overrides keep winning. Covers every NixOS host via the base module.
- **`feat(darwin)`** — new shared `modules/darwin-nix-maintenance` (nix-darwin launchd `interval` GC + optimise + min-free/max-free), registered in `darwin-modules.nix`, imported by both macOS hosts. Redundant commented stubs removed.
- **`feat(home)`** — home-manager `nix.gc` weekly timer on standalone `ali` + `deck`. Multi-user-daemon caveat: a user config can't set daemon-level `min-free`/`auto-optimise`, so these get periodic GC only.
- **`fix(home-only)`** — drop stale `self.overlays.qbittorrent` reference (overlay removed; was blocking the `ali`/`deck` configs from evaluating).

## Verification

`nix eval` (not build — x86_64/aarch64-linux verified by eval per repo convention; real builds on host/deploy/CI):

- NixOS: `min-free=5 GiB`, `auto-optimise-store=true`, `optimise.automatic=true` ✓
- k8s-master mkForce override still wins: `min-free=50 GiB` ✓
- Darwin (ali-mba + Alisons-MacBook-Pro): `gc.automatic`, `min-free`, `optimise.automatic`, `auto-optimise-store` ✓
- All edited files parse clean ✓

## Known pre-existing issue (not addressed here)

The `ali`/`deck` homeConfigurations have a further pre-existing eval break: `home/programs/linux-only/zen-browser` references `stylix` options but the standalone configs don't import the stylix home module (`error: The option 'stylix' does not exist`). Out of scope; the home-manager GC additions are standard `nix.gc` options and parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)