### PR TITLE
perf(home-kvm-hypervisor-1): RAM relief + VM/host performance tuning

### DIFF
--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -88,6 +88,18 @@ in {
             sysctl = {
               "net.ipv4.conf.all.forwarding" = true;
               "net.ipv6.conf.all.forwarding" = true;
+
+              # Bound dirty (un-flushed) page-cache in absolute bytes instead of
+              # the default ratios. dirty_ratio=20 on a 30.5 GiB host lets ~6 GiB
+              # of dirty pages accumulate before a writer blocks — on a host
+              # where ~22 GiB is mlock-pinned by passthrough VMs that spike
+              # competes for the little remaining RAM. Cap at 1 GiB / 256 MiB bg.
+              # bytes and ratio are mutually exclusive, so the base ratios MUST
+              # be forced to 0 or the kernel keeps using them.
+              "vm.dirty_bytes" = 1073741824;            # 1 GiB
+              "vm.dirty_background_bytes" = 268435456;  # 256 MiB
+              "vm.dirty_ratio" = lib.mkForce 0;
+              "vm.dirty_background_ratio" = lib.mkForce 0;
             };
           };
 

--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -65,6 +65,18 @@ in {
         boot = {
           kernelPackages = pkgs.linuxPackages_latest;
 
+          # This board boots GRUB purely via the EFI removable/fallback path
+          # (\EFI\BOOT\BOOTX64.EFI on each RAID1 ESP member); there is no
+          # persistent "nixos" NVRAM boot entry. The firmware rejects
+          # efibootmgr NVRAM writes ("Operation not permitted"), so the base
+          # module's canTouchEfiVariables=true made every deploy's grub-install
+          # exit non-zero even though grub.cfg updated fine. Install as
+          # removable and stop touching EFI variables to match reality.
+          loader = {
+            efi.canTouchEfiVariables = lib.mkForce false;
+            grub.efiInstallAsRemovable = lib.mkForce true;
+          };
+
           kernelParams = [
             # SAS3008 controllers (1000:0097) bound early via vfio-pci — prevents mpt3sas from claiming them
             # GPU (1002:164e) stays on amdgpu for LUKS prompt; libvirt rebinds it when VM starts (managed='yes')

--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -129,6 +129,13 @@ in {
           };
         };
 
+        # Cap zram at 50% of RAM (base sets 100%). zram is RAM-backed, so on a
+        # host this tight an oversized zram could itself consume the RAM it is
+        # meant to relieve. With swappiness raised, more lands in zram — this is
+        # the guardrail. Only ~8.5 GiB is swappable here (22 GiB pinned), so
+        # 50% is a safe ceiling, not a throughput limit.
+        zramSwap.memoryPercent = lib.mkForce 50;
+
         console.keyMap = "us";
 
         environment = {

--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -207,7 +207,11 @@ in {
                     definition = pkgs.writeText "home-storage-server-1.xml" (import (self + "/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix") {inherit pkgs;});
                   }
                   {
-                    active = true;
+                    # Disabled: not needed. active=false keeps the domain defined
+                    # but stopped and prevents libvirt autostart, reclaiming its
+                    # 4 GiB reservation for the other VMs (notably jellyfin on
+                    # home-k8s-master-1). Re-enable by flipping back to true.
+                    active = false;
                     definition = pkgs.writeText "home-vpn-gateway-1.xml" (import (self + "/libvirtd/home-kvm-hypervisor-1/domains/home-vpn-gateway-1.xml.nix") {inherit pkgs;});
                   }
                   # {

--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -100,6 +100,15 @@ in {
               "vm.dirty_background_bytes" = 268435456;  # 256 MiB
               "vm.dirty_ratio" = lib.mkForce 0;
               "vm.dirty_background_ratio" = lib.mkForce 0;
+
+              # Push cold anonymous pages of the swappable tenants (download +
+              # storage VMs, host daemons) into zram aggressively to free real
+              # RAM — frees ~2 GiB. The pinned jellyfin VM is exempt (its RAM is
+              # mlock'd, unswappable at any swappiness). page-cluster=0 reads one
+              # page per swap-in: zram is random-access RAM, so the default
+              # 8-page readahead just wastes work.
+              "vm.swappiness" = 100;
+              "vm.page-cluster" = 0;
             };
           };
 

--- a/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
@@ -9,7 +9,7 @@
     </metadata>
     <memory unit='KiB'>4194304</memory>
     <currentMemory unit='KiB'>4194304</currentMemory>
-    <vcpu placement='static'>16</vcpu>
+    <vcpu placement='static'>4</vcpu>
     <os firmware='efi'>
       <type arch='x86_64' machine='pc-q35-9.1'>hvm</type>
       <firmware>
@@ -25,7 +25,9 @@
       <vmport state='off'/>
       <smm state='on'/>
     </features>
-    <cpu mode='host-passthrough' check='none' migratable='on'/>
+    <cpu mode='host-passthrough' check='none' migratable='on'>
+      <topology sockets='1' cores='4' threads='1'/>
+    </cpu>
     <clock offset='utc'>
       <timer name='rtc' tickpolicy='catchup'/>
       <timer name='pit' tickpolicy='delay'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
@@ -28,6 +28,9 @@
     <cpu mode='host-passthrough' check='none' migratable='on'>
       <topology sockets='1' cores='4' threads='1'/>
     </cpu>
+    <cputune>
+      <shares>512</shares>
+    </cputune>
     <clock offset='utc'>
       <timer name='rtc' tickpolicy='catchup'/>
       <timer name='pit' tickpolicy='delay'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
@@ -41,7 +41,7 @@
     <devices>
       <emulator>/run/libvirt/nix-emulators/qemu-system-x86_64</emulator>
       <disk type='file' device='disk'>
-        <driver name='qemu' type='qcow2' discard='unmap'/>
+        <driver name='qemu' type='qcow2' cache='none' io='native' discard='unmap'/>
         <source file='/var/lib/libvirt/images/download-server-1.qcow2'/>
         <target dev='vda' bus='virtio'/>
         <boot order='2'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
@@ -50,7 +50,7 @@
     <devices>
       <emulator>/run/libvirt/nix-emulators/qemu-system-x86_64</emulator>
       <disk type='file' device='disk'>
-        <driver name='qemu' type='qcow2' discard='unmap'/>
+        <driver name='qemu' type='qcow2' cache='none' io='native' discard='unmap'/>
         <source file='/var/lib/libvirt/images/home-k8s-master-1.qcow2'/>
         <target dev='vda' bus='virtio'/>
         <boot order='2'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
@@ -18,7 +18,7 @@
          (pinned VMs can't resize live): virsh destroy && virsh start. -->
     <memory unit='KiB'>18432000</memory>
     <currentMemory unit='KiB'>18432000</currentMemory>
-    <vcpu placement='static'>16</vcpu>
+    <vcpu placement='static'>8</vcpu>
     <os firmware='efi'>
       <type arch='x86_64' machine='pc-q35-9.1'>hvm</type>
       <firmware>
@@ -34,7 +34,9 @@
       <vmport state='off'/>
       <smm state='on'/>
     </features>
-    <cpu mode='host-passthrough' check='none' migratable='on'/>
+    <cpu mode='host-passthrough' check='none' migratable='on'>
+      <topology sockets='1' cores='8' threads='1'/>
+    </cpu>
     <clock offset='utc'>
       <timer name='rtc' tickpolicy='catchup'/>
       <timer name='pit' tickpolicy='delay'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
@@ -7,8 +7,17 @@
         <libosinfo:os id="http://libosinfo.org/linux/2022"/>
       </libosinfo:libosinfo>
     </metadata>
-    <memory unit='KiB'>16384000</memory>
-    <currentMemory unit='KiB'>16384000</currentMemory>
+    <!-- 18000 MiB. Bumped from 16000 MiB: this guest runs k3s + Jellyfin +
+         Prometheus/Grafana and was swapping ~5 GiB under pressure. The VM has a
+         GPU <hostdev> passthrough so QEMU mlocks ALL guest RAM resident (no
+         balloon/swap on the host side) — every KiB here is pinned host RAM.
+         18000 MiB is the safe ceiling: 30.5 GiB host - 18 (this, pinned)
+         - 4 (storage, pinned) - ~2.5 (host) leaves ~6 GiB for download-server-1
+         (4 GiB, swappable). Do NOT exceed while storage keeps its HBA. Reclaimed
+         headroom comes from the disabled vpn-gateway. Cold power-cycle to apply
+         (pinned VMs can't resize live): virsh destroy && virsh start. -->
+    <memory unit='KiB'>18432000</memory>
+    <currentMemory unit='KiB'>18432000</currentMemory>
     <vcpu placement='static'>16</vcpu>
     <os firmware='efi'>
       <type arch='x86_64' machine='pc-q35-9.1'>hvm</type>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
@@ -37,6 +37,9 @@
     <cpu mode='host-passthrough' check='none' migratable='on'>
       <topology sockets='1' cores='8' threads='1'/>
     </cpu>
+    <cputune>
+      <shares>4096</shares>
+    </cputune>
     <clock offset='utc'>
       <timer name='rtc' tickpolicy='catchup'/>
       <timer name='pit' tickpolicy='delay'/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
@@ -36,6 +36,9 @@
   <cpu mode="host-passthrough" check="none" migratable="on">
     <topology sockets="1" cores="4" threads="1"/>
   </cpu>
+  <cputune>
+    <shares>512</shares>
+  </cputune>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
@@ -16,7 +16,7 @@
     <source type="memfd"/>
     <access mode="shared"/>
   </memoryBacking>
-  <vcpu placement="static">16</vcpu>
+  <vcpu placement="static">4</vcpu>
   <os firmware="efi">
     <type arch="x86_64" machine="pc-q35-9.1">hvm</type>
     <firmware>
@@ -33,7 +33,9 @@
     <vmport state="off"/>
     <smm state="on"/>
   </features>
-  <cpu mode="host-passthrough" check="none" migratable="on"/>
+  <cpu mode="host-passthrough" check="none" migratable="on">
+    <topology sockets="1" cores="4" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-vpn-gateway-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-vpn-gateway-1.xml.nix
@@ -9,7 +9,7 @@
     </metadata>
     <memory unit='KiB'>4194304</memory>
     <currentMemory unit='KiB'>4194304</currentMemory>
-    <vcpu placement='static'>16</vcpu>
+    <vcpu placement='static'>2</vcpu>
     <os firmware='efi'>
       <type arch='x86_64' machine='pc-q35-9.1'>hvm</type>
       <firmware>
@@ -25,7 +25,9 @@
       <vmport state='off'/>
       <smm state='on'/>
     </features>
-    <cpu mode='host-passthrough' check='none' migratable='on'/>
+    <cpu mode='host-passthrough' check='none' migratable='on'>
+      <topology sockets='1' cores='2' threads='1'/>
+    </cpu>
     <clock offset='utc'>
       <timer name='rtc' tickpolicy='catchup'/>
       <timer name='pit' tickpolicy='delay'/>

--- a/modules/libvirtd/default.nix
+++ b/modules/libvirtd/default.nix
@@ -17,6 +17,12 @@ in
     virtualisation.libvirtd = {
       enable = true;
       parallelShutdown = cfg.parallelShutdown;
+      # Gracefully ACPI-shutdown guests on host shutdown/reboot instead of the
+      # default "suspend" (managedsave). VMs with PCI <hostdev> passthrough
+      # (home-k8s-master-1 GPU, home-storage-server-1 HBA) cannot be
+      # managed-saved — libvirt-guests would fail the save and hard-kill them
+      # ungracefully on every host reboot. "shutdown" avoids that.
+      onShutdown = "shutdown";
       qemu = {
         package = pkgs.qemu_kvm.override { cephSupport = false; };
         runAsRoot = true;


### PR DESCRIPTION
Audit-driven RAM relief and performance tuning for `home-kvm-hypervisor-1` (30.5 GiB / 16-thread host running 3 active VMs). Driven by a RAM shortage on the VMs.

## Key finding
The Jellyfin VM (`home-k8s-master-1`) has GPU `<hostdev>` passthrough, so QEMU **mlocks all its guest RAM resident** — un-swappable, un-balloonable, un-KSM-able. Host-side `virsh dommemstat` reports it as idle (stale balloon stat); measured inside the guest it was using 10 GiB and **swapping ~5 GiB** — genuinely starved. So it gets *more* RAM, while headroom is reclaimed elsewhere.

## Changes (atomic commits)
- **disable `home-vpn-gateway-1` autostart** — not needed, reclaims 4 GiB
- **jellyfin RAM 16000 → 18000 MiB** — the safe ceiling given the pinned-RAM budget
- **`onShutdown=shutdown`** — passthrough VMs can't managed-save; default `suspend` hard-killed them on every host reboot
- **qcow2 `cache=none io=native`** (k8s + download) — stops host double-buffering guest I/O, ~3–4 GiB page-cache back
- **right-size vCPUs 8/4/4/2 + CPU topology** — was 16 each on a 16-thread host
- **`cputune` shares** — prioritise jellyfin under contention
- **GRUB EFI removable install, no NVRAM writes** — board boots via `\EFI\BOOT\BOOTX64.EFI` fallback; firmware rejected efibootmgr writes, failing every deploy
- **bounded dirty page-cache** (1 GiB / 256 MiB bytes, ratios forced 0) — was ~6 GiB on default ratio
- **swappiness=100 + page-cluster=0** — push cold anon of swappable VMs into zram (~2 GiB)
- **cap zram at 50%** — guardrail so RAM-backed zram can't eat the RAM it relieves

## Net (after reboot)
~7–8 GiB host headroom reclaimed AND +2 GiB to the starved jellyfin VM; bounded dirty spikes; no CPU overcommit; graceful guest shutdown; clean deploys.

## Deploy state
Already **boot-deployed** to the host (`nixos-rebuild boot`); activates on next reboot (which also cold-restarts VMs, required for the pinned jellyfin resize). Built clean; deploy exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)