### PR TITLE
perf(download/storage): hardlink imports + isolated jumbo NFS path

### DIFF
--- a/flake-modules/hosts/download-server-1/default.nix
+++ b/flake-modules/hosts/download-server-1/default.nix
@@ -327,6 +327,30 @@ in {
             # '';
           };
 
+          # Static config for the second (jumbo) NIC on br-storage, bound by its
+          # fixed MAC. Isolated point-to-point with home-storage-server-1
+          # (10.10.10.2); no gateway/DNS, so the directly-connected /24 route
+          # carries NFS straight to storage (off both the LAN br0 and the wg-quick
+          # VPN default route). MTU 9000 must match every hop.
+          networkmanager.ensureProfiles.profiles = {
+            storage-jumbo = {
+              connection = {
+                id = "storage-jumbo";
+                type = "ethernet";
+                autoconnect = true;
+              };
+              ethernet = {
+                mac-address = "52:54:00:0A:29:40";
+                mtu = 9000;
+              };
+              ipv4 = {
+                method = "manual";
+                address1 = "10.10.10.1/24";
+              };
+              ipv6.method = "disabled";
+            };
+          };
+
           wg-quick = {
             interfaces = {
               primary-vpn = {
@@ -1203,11 +1227,18 @@ EOF
           UMask = lib.mkForce "0002";
         };
 
-        # Ensure mount points exist
+        # Single mount point for the whole storage pool, plus compatibility
+        # symlinks so the apps keep their existing paths. Because /media/downloads,
+        # /media/movies and /media/tv now resolve into ONE NFS mount
+        # (/media/storage), Sonarr/Radarr see the download dir and the library on
+        # the same st_dev and HARDLINK imports instead of copying the file back
+        # over NFS. L+ force-replaces the old (now stale) empty mountpoint dirs
+        # with symlinks on activation.
         systemd.tmpfiles.rules = [
-          "d /media/downloads 0755 root root -"
-          "d /media/movies 0755 root root -"
-          "d /media/tv 0755 root root -"
+          "d /media/storage 0755 root root -"
+          "L+ /media/downloads - - - - /media/storage/downloads"
+          "L+ /media/movies - - - - /media/storage/media/Movies"
+          "L+ /media/tv - - - - /media/storage/media/TV"
         ];
 
         # NFS mounts of the storage server (192.168.1.97), which exports a
@@ -1256,51 +1287,29 @@ EOF
         #   - READDIRPLUS (default)  bundled readdir+stat -> fast listings
         #   - async (downloads only) faster writes; safe, qBittorrent verifies
         #   - hard                   retry on server hiccups (no data loss)
+        # ONE mount of the mergerfs pool root, exported just for this host (see
+        # home-storage-server-1 exports). Replaces the previous three subdir
+        # mounts so that the download dir and the *arr library share a single
+        # st_dev -> imports HARDLINK (server-side metadata op) instead of copying
+        # the file back over NFS. /media/{downloads,movies,tv} are symlinks into
+        # this mount (tmpfiles above) so app paths are unchanged.
+        #
+        # Target 10.10.10.2 = storage's jumbo (MTU 9000, br-storage) IP, keeping
+        # the bulk NFS traffic on the isolated fast path off the LAN br0. To fall
+        # back to the LAN, change this to 192.168.1.97 (the root export also
+        # allows download-server-1.lan).
+        #
+        # async dropped (the old downloads-only knob): one mount can't be both
+        # async and sync, and with hardlinks the import writes ~nothing anyway.
+        # nconnect raised 4 -> 8. lookupcache=none retained (mandatory — see the
+        # block comment above). softreval + hard + TimeoutSec=120 as before.
         systemd.mounts = [
           {
-            what = "192.168.1.97:/media/storage/downloads";
-            where = "/media/downloads";
+            what = "10.10.10.2:/media/storage";
+            where = "/media/storage";
             type = "nfs";
-            # downloads: async is safe here (qBittorrent verifies its own data).
-            # lookupcache=none is mandatory — see the block comment above.
-            # softreval: serve last-good cached attrs if a revalidation RPC times
-            #   out during a storage stall (default is nosoftreval) -> fewer
-            #   false-missing. Safe with hard (false-present is benign for *arr;
-            #   false-missing is the failure we fear).
-            # x-systemd.mount-timeout was removed: it is IGNORED in unit files
-            #   (only honoured in /etc/fstab) — use native mountConfig.TimeoutSec.
-            options = "rw,hard,softreval,tcp,nfsvers=4.2,rsize=1048576,wsize=1048576,timeo=600,retrans=2,noatime,nodiratime,async,nconnect=4,lookupcache=none,acregmin=3,acregmax=30,acdirmin=5,acdirmax=30";
+            options = "rw,hard,softreval,tcp,nfsvers=4.2,rsize=1048576,wsize=1048576,timeo=600,retrans=2,noatime,nodiratime,nconnect=8,lookupcache=none,acregmin=3,acregmax=30,acdirmin=5,acdirmax=30";
             mountConfig.TimeoutSec = "120";  # ride out a scrub stall; not infinity (hard already blocks established I/O)
-            wantedBy = [ ];
-            requires = [ "network-online.target" ];
-            after = [ "network-online.target" ];
-          }
-          {
-            what = "192.168.1.97:/media/storage/media/Movies";
-            where = "/media/movies";
-            type = "nfs";
-            # movies/tv: no async (Radarr/Sonarr move completed files here).
-            # lookupcache=none is mandatory — see the block comment above.
-            # softreval: serve last-good attrs on revalidation timeout (fewer
-            #   false-missing under load). x-systemd.mount-timeout removed (no-op
-            #   in unit files) -> native mountConfig.TimeoutSec instead.
-            options = "rw,hard,softreval,tcp,nfsvers=4.2,rsize=1048576,wsize=1048576,timeo=600,retrans=2,noatime,nodiratime,nconnect=4,lookupcache=none,acregmin=3,acregmax=30,acdirmin=5,acdirmax=30";
-            mountConfig.TimeoutSec = "120";
-            wantedBy = [ ];
-            requires = [ "network-online.target" ];
-            after = [ "network-online.target" ];
-          }
-          {
-            what = "192.168.1.97:/media/storage/media/TV";
-            where = "/media/tv";
-            type = "nfs";
-            # movies/tv: no async (Radarr/Sonarr move completed files here).
-            # lookupcache=none is mandatory — see the block comment above.
-            # softreval: serve last-good attrs on revalidation timeout (fewer
-            #   false-missing under load). x-systemd.mount-timeout removed (no-op
-            #   in unit files) -> native mountConfig.TimeoutSec instead.
-            options = "rw,hard,softreval,tcp,nfsvers=4.2,rsize=1048576,wsize=1048576,timeo=600,retrans=2,noatime,nodiratime,nconnect=4,lookupcache=none,acregmin=3,acregmax=30,acdirmin=5,acdirmax=30";
-            mountConfig.TimeoutSec = "120";
             wantedBy = [ ];
             requires = [ "network-online.target" ];
             after = [ "network-online.target" ];
@@ -1309,18 +1318,34 @@ EOF
 
         systemd.automounts = [
           {
-            where = "/media/downloads";
-            wantedBy = [ "multi-user.target" ];
-          }
-          {
-            where = "/media/movies";
-            wantedBy = [ "multi-user.target" ];
-          }
-          {
-            where = "/media/tv";
+            where = "/media/storage";
             wantedBy = [ "multi-user.target" ];
           }
         ];
+
+        # Turn on virtio-net multiqueue (the device offers 4 queues but Linux
+        # uses 1 until told). Spreads NIC softirq across the 4 vCPUs under the
+        # many parallel torrent + NFS streams. Matches by driver -> both NICs.
+        systemd.services.virtio-nic-multiqueue = {
+          description = "Enable virtio-net multiqueue on all virtio NICs";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          path = [ pkgs.ethtool pkgs.coreutils pkgs.gawk ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            for dev in /sys/class/net/*; do
+              name=$(basename "$dev")
+              [ -e "$dev/device/driver" ] || continue
+              case "$(readlink "$dev/device/driver")" in *virtio*) ;; *) continue ;; esac
+              max=$(ethtool -l "$name" 2>/dev/null | awk '/^Combined:/{print $2; exit}')
+              [ -n "$max" ] && [ "$max" -gt 1 ] && ethtool -L "$name" combined "$max" || true
+            done
+          '';
+        };
 
         # Generate self-signed certificate for nginx
         systemd.services.nginx-self-signed-cert = {

--- a/flake-modules/hosts/download-server-1/default.nix
+++ b/flake-modules/hosts/download-server-1/default.nix
@@ -1816,11 +1816,20 @@ EOF
 
             lanSubnets = [
               "192.168.1.0/24"
+              # Isolated jumbo storage network (br-storage) to
+              # home-storage-server-1. Without this the VPN killswitch's
+              # output chain (policy drop) blocks NFS to 10.10.10.2.
+              "10.10.10.0/24"
             ];
 
             lanInterfaces = [
               "enp1s0"
               "tailscale0"
+              # Second NIC on br-storage carrying NFS to the storage server.
+              # Name is the libvirt-assigned PCI slot (persisted in the domain
+              # XML, so stable across restarts). If a future domain recreation
+              # renames it, update this to match `ip -br link` on the guest.
+              "enp7s0"
             ];
 
             vpnEndpoints = [

--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -191,6 +191,18 @@ in {
                   Name = "br0";
                 };
               };
+
+              # Isolated, host-only L2 bridge carrying the jumbo (MTU 9000)
+              # storage network between download-server-1 and home-storage-server-1.
+              # No physical uplink and no host IP — pure guest<->guest fast path so
+              # the NFS data traffic stays off br0 (which must remain MTU 1500 for
+              # the LAN). Guests attach a second virtio NIC to this bridge.
+              "21-br-storage" = {
+                netdevConfig = {
+                  Kind = "bridge";
+                  Name = "br-storage";
+                };
+              };
             };
 
             networks = {
@@ -211,6 +223,21 @@ in {
                 dhcpV4Config = { UseDNS = true; UseRoutes = true; };
                 linkConfig = {
                   RequiredForOnline = "routable";
+                };
+              };
+
+              # br-storage carries no host IP; force MTU 9000 and let it come up
+              # without a carrier (members appear only when guests boot). Not
+              # required for boot-online so a guest-down state never blocks the host.
+              "41-br-storage" = {
+                matchConfig.Name = "br-storage";
+                networkConfig = {
+                  ConfigureWithoutCarrier = true;
+                  LinkLocalAddressing = "no";
+                };
+                linkConfig = {
+                  MTUBytes = "9000";
+                  RequiredForOnline = "no";
                 };
               };
             };

--- a/flake-modules/hosts/home-storage-server-1/default.nix
+++ b/flake-modules/hosts/home-storage-server-1/default.nix
@@ -168,6 +168,52 @@ in {
               111   # RPC
             ];
           };
+
+          # Static config for the second (jumbo) NIC on br-storage, bound by its
+          # fixed MAC. Isolated point-to-point with download-server-1 (10.10.10.1);
+          # no gateway/DNS. MTU 9000 must match every hop (bridge + taps + peer).
+          networkmanager.ensureProfiles.profiles = {
+            storage-jumbo = {
+              connection = {
+                id = "storage-jumbo";
+                type = "ethernet";
+                autoconnect = true;
+              };
+              ethernet = {
+                mac-address = "52:54:00:69:9C:40";
+                mtu = 9000;
+              };
+              ipv4 = {
+                method = "manual";
+                address1 = "10.10.10.2/24";
+              };
+              ipv6.method = "disabled";
+            };
+          };
+        };
+
+        # Turn on virtio-net multiqueue (the device offers 4 queues but Linux
+        # uses 1 until told). Spreads NIC softirq across the 4 vCPUs under the
+        # parallel NFS streams. Matches by driver so it covers both NICs.
+        systemd.services.virtio-nic-multiqueue = {
+          description = "Enable virtio-net multiqueue on all virtio NICs";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          path = [ pkgs.ethtool pkgs.coreutils pkgs.gawk ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            for dev in /sys/class/net/*; do
+              name=$(basename "$dev")
+              [ -e "$dev/device/driver" ] || continue
+              case "$(readlink "$dev/device/driver")" in *virtio*) ;; *) continue ;; esac
+              max=$(ethtool -l "$name" 2>/dev/null | awk '/^Combined:/{print $2; exit}')
+              [ -n "$max" ] && [ "$max" -gt 1 ] && ethtool -L "$name" combined "$max" || true
+            done
+          '';
         };
 
         # Set proper ownership and permissions on media directories
@@ -238,6 +284,18 @@ in {
 
               # TV share - for Sonarr
               /media/storage/media/TV     192.168.1.0/24(rw,sync,no_subtree_check,no_root_squash,fsid=00a0212d-447f-487d-afbc-3faaafab5b73)
+
+              # Pool-ROOT export for download-server-1 ONLY, so it mounts the
+              # whole union once and Sonarr/Radarr can HARDLINK imports
+              # (downloads + media library under one st_dev) instead of copying
+              # every file back over NFS. Own fresh random fsid (mergerfs/FUSE
+              # shares st_dev -> each export needs a distinct fsid). NO
+              # crossmnt/nohide (ESTALE on FUSE). Restricted to the download box:
+              # 10.10.10.1 = its jumbo (br-storage) IP (primary path), plus its
+              # LAN FQDN as a fallback if the jumbo path is ever pointed back at
+              # br0. The three exports above are untouched -> other clients
+              # (Jellyfin/k8s, desktops) unaffected.
+              /media/storage  10.10.10.1(rw,sync,no_subtree_check,no_root_squash,fsid=e3fdacb1-c2cf-472d-b686-b53f12e8639f) download-server-1.lan(rw,sync,no_subtree_check,no_root_squash,fsid=e3fdacb1-c2cf-472d-b686-b53f12e8639f)
             '';
           };
 

--- a/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/download-server-1.xml.nix
@@ -143,7 +143,19 @@
         <mac address='52:54:00:0a:29:2d'/>
         <source bridge='br0'/>
         <model type='virtio'/>
+        <driver queues='4'/>
         <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+      </interface>
+      <!-- Second NIC on the isolated jumbo (MTU 9000) storage bridge. Carries
+           NFS traffic to home-storage-server-1 (10.10.10.2) off the LAN br0.
+           Multiqueue (queues=4) spreads NIC softirq across the 4 vCPUs. PCI
+           address omitted so libvirt auto-assigns a free pcie-root-port. -->
+      <interface type='bridge'>
+        <mac address='52:54:00:0a:29:40'/>
+        <source bridge='br-storage'/>
+        <model type='virtio'/>
+        <driver queues='4'/>
+        <mtu size='9000'/>
       </interface>
       <serial type='pty'>
         <target type='isa-serial' port='0'>

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
@@ -151,7 +151,19 @@
       <mac address="52:54:00:69:9c:5c"/>
       <source bridge="br0"/>
       <model type="virtio"/>
+      <driver queues="4"/>
       <address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
+    </interface>
+    <!-- Second NIC on the isolated jumbo (MTU 9000) storage bridge. Serves NFS
+         to download-server-1 (10.10.10.1) off the LAN br0. Multiqueue (queues=4)
+         spreads NIC softirq across the 4 vCPUs. PCI address omitted so libvirt
+         auto-assigns a free pcie-root-port. -->
+    <interface type="bridge">
+      <mac address="52:54:00:69:9c:40"/>
+      <source bridge="br-storage"/>
+      <model type="virtio"/>
+      <driver queues="4"/>
+      <mtu size="9000"/>
     </interface>
     <serial type="pty">
       <target type="isa-serial" port="0">


### PR DESCRIPTION
Optimise the download-server-1 → home-storage-server-1 data workflow (both KVM guests on home-kvm-hypervisor-1, NFS over the host bridge).

## Headline: eliminate the import copy via hardlinks
Storage exported the mergerfs pool as three separate subdir exports, mounted as three mounts on the download box. Different mounts = different `st_dev`, so Sonarr/Radarr couldn't hardlink and instead **read each imported file down over NFS and wrote it back up** to the same pool/disk — double network + double disk until seeding ended.

Fix: add a single pool-**root** export (own fsid, restricted to the download box) and mount it **once**; `/media/{downloads,movies,tv}` become symlinks into it. Apps keep their paths; source and dest now share one `st_dev`, so imports become a **server-side hardlink** (no data over the wire, no double disk). Existing three exports untouched → other clients (Jellyfin/k8s, desktops) unaffected.

virtiofs was ruled out — the disks are HBA-passthrough *into* the storage guest, so the host can't share them; guest↔guest needs a network transport.

## Plus: isolated jumbo storage network + NFS tuning
- New host-only bridge `br-storage` (MTU 9000, no uplink) + a 2nd virtio NIC per guest (10.10.10.1/.2), so bulk NFS leaves the LAN br0.
- virtio multiqueue (`queues=4`) on the guest NICs; `nconnect` 4→8.
- download-server's VPN killswitch (`proxyVpnGateway`, nftables output policy-drop) had to whitelist the new jumbo iface/subnet, or it silently dropped all NFS to storage (ARP resolved but ICMP/TCP never egressed).

## Verified on hardware
Mount active (`10.10.10.2:/media/storage`, nconnect=8, MTU 9000); `/media/{downloads,movies,tv}` resolve to nfs same-device; cross-subdir `ln` yields dest `nlink=2` (real hardlink). Multiqueue combined=4.

## Notes
- Jumbo/multiqueue are marginal (storage is HDD+sync-bound); the hardlink change is the real win.
- ICMP stays blocked by the killswitch on the jumbo path by design — test with NFS/TCP, not ping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)