### PR TITLE
fix(download-server-1): qbittorrent mount dependency after unified NFS mount

### DIFF
--- a/flake-modules/hosts/download-server-1/default.nix
+++ b/flake-modules/hosts/download-server-1/default.nix
@@ -935,9 +935,11 @@ in {
 
         # Override qbittorrent service to inject secrets and configure aggressive restarts
         systemd.services.qbittorrent = {
-          # Restart qBittorrent if NFS mounts are remounted (prevents stale file handles)
-          bindsTo = [ "media-downloads.mount" ];
-          after = [ "media-downloads.mount" "media-movies.mount" "media-tv.mount" ];
+          # Restart qBittorrent if the NFS mount is remounted (prevents stale
+          # file handles). The pool is now a single mount (/media/storage); the
+          # old per-subdir mounts are symlinks into it.
+          bindsTo = [ "media-storage.mount" ];
+          after = [ "media-storage.mount" ];
 
           # Re-run the config-merger (and thus re-apply the auth whitelist /
           # port / password) whenever the merger script changes, so a deploy


### PR DESCRIPTION
qBittorrent stayed dead after the single-NFS-mount change (#147), returning nginx 502. Its unit still had `bindsTo`/`after` the removed per-subdir mount units (`media-downloads.mount` etc.), so systemd refused to start it ("Unit media-downloads.mount not found"). Repoint at `media-storage.mount`.

Verified: qbittorrent active, WebUI 200 locally and through nginx (502 gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)