### PR TITLE
feat: match hypervisor LAN uplink by driver for EPYC board swap

### DIFF
--- a/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
+++ b/flake-modules/hosts/home-kvm-hypervisor-1/default.nix
@@ -206,8 +206,16 @@ in {
             };
 
             networks = {
-              "30-enp16s0" = {
-                matchConfig.Name = "enp16s0";
+              # Match the LAN uplink by driver, not interface name, so this
+              # survives the EPYC/ROMED8-2T board swap. ixgbe matches the
+              # current board's enp16s0 today and the new board's onboard Intel
+              # X550 after the swap. On the new board both X550 ports match;
+              # only the cabled LAN port has carrier, so br0 DHCPs over it with
+              # no loop. The second (WAN-reserved) port sits enslaved with no
+              # carrier until the firewall VM is built, at which point it gets
+              # carved out for passthrough.
+              "30-lan-uplink" = {
+                matchConfig.Driver = "ixgbe";
                 networkConfig = {
                   Bridge = "br0";
                 };


### PR DESCRIPTION
## Context

`home-kvm-hypervisor-1` is moving from its current consumer platform (Ryzen 7700 / B650) to an **EPYC 7543 + ASRock Rack ROMED8-2T**. The existing NVMe boot disks + SAS HBA carry over and **no OS reinstall** is wanted — the existing NixOS install on the NVMe RAID1 should boot on the new board.

This PR is deployed to the **current** board *before* the hardware swap, so it must keep the current host working as well as the new one. It therefore changes only what is valid on **both** boards and removes nothing.

## The problem

`flake-modules/hosts/home-kvm-hypervisor-1/default.nix` enslaved the `br0` LAN uplink by interface **name**:

```nix
"30-enp16s0" = { matchConfig.Name = "enp16s0"; ... };
```

On the ROMED8-2T the onboard Intel **X550** ports enumerate under a different predictable name → the match fails → the headless host boots with **no network**.

## The fix

Match the uplink by **driver** instead. The current uplink `enp16s0` is already an `ixgbe` device and the X550 is also `ixgbe`, so `Driver = "ixgbe"` resolves correctly on **both** boards:

```nix
"30-lan-uplink" = { matchConfig.Driver = "ixgbe"; ... };
```

Keeps the current host online after deploy **and** guarantees first-boot network after the swap. On the new board both X550 ports match; only the cabled LAN port has carrier, so `br0` DHCPs over it with no loop. IPMI remote console is the safety net regardless.

## Why the change is this small

Everything else already survives a board swap (verified against the host config):
- **LUKS** uses a passphrase, not TPM/PCR sealing → swap-safe (no TPM on this host).
- **Bootloader** is GRUB EFI-removable (`\EFI\BOOT\BOOTX64.EFI`, no NVRAM entry) → boots on new firmware as-is.
- **mdraid + LVM + LUKS** assemble by UUID → NVMe renumbering is irrelevant.
- **HBA passthrough** is bound by PCI ID (`vfio-pci.ids=1000:0097`) → same card survives.
- `kvm-amd`, AMD microcode, and `ixgbe` are already present.

## Verification

- ✅ `nix build .#nixosConfigurations.home-kvm-hypervisor-1.config.system.build.toplevel` (exit 0)
- `nix flake check` running locally; CI `build-and-cache` validates on push.

**Post-swap (manual):** connect IPMI → power on → enter LUKS passphrase at console → confirm `br0` gets a DHCP lease over the X550 → `just deploy .#home-kvm-hypervisor-1`.

## Follow-up (after swap confirmed)

Separate cleanup PR removes the old board's now-dead `mt7921e` / `r8169` initrd modules and the stale commented `enp*` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)