### PR TITLE
fix(desktop): Scarlett USB audio crackle + XRUN silence — timer-based scheduling

### DIFF
--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -649,8 +649,15 @@ in {
               pkgs.uhk-udev-rules
             ];
             extraRules = ''
-              # Fix 8BitDo Ultimate Wireless Controller connection issues (autosuspend)
-              ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2dc8", ATTR{idProduct}=="3106", ATTR{power/control}="on"
+              # Keep the Scarlett 2i2 4th Gen USB audio interface fully powered.
+              # It sits behind a USB switch + hub shared with the controllers below;
+              # autosuspend churn on that hub jitters its isochronous audio stream.
+              ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1235", ATTR{idProduct}=="8219", ATTR{power/control}="on", ATTR{power/autosuspend}="-1"
+
+              # Fix 8BitDo Ultimate Wireless Controller connection issues (autosuspend).
+              # Shares the Scarlett's hub branch; its autosuspend re-enumeration storms
+              # (descriptor read error -32 / -71 at boot) disrupt the audio device.
+              ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2dc8", ATTR{idProduct}=="3109", ATTR{power/control}="on"
 
               # Use adios I/O scheduler on all storage devices (CachyOS kernel only).
               # adios = adaptive deadline scheduler — better mixed-workload latency than `none`,

--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -652,7 +652,7 @@ in {
               # Keep the Scarlett 2i2 4th Gen USB audio interface fully powered.
               # It sits behind a USB switch + hub shared with the controllers below;
               # autosuspend churn on that hub jitters its isochronous audio stream.
-              ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1235", ATTR{idProduct}=="8219", ATTR{power/control}="on", ATTR{power/autosuspend}="-1"
+              ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1235", ATTR{idProduct}=="8219", ATTR{power/control}="on"
 
               # Fix 8BitDo Ultimate Wireless Controller connection issues (autosuspend).
               # Shares the Scarlett's hub branch; its autosuspend re-enumeration storms

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -226,6 +226,54 @@ in
           is selected at device monitor time.
         '';
       };
+
+      usbAudioStability = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Give USB audio interfaces larger, more resilient buffers than the
+          aggressive low-latency settings used for internal/wired ALSA.
+
+          USB audio is isochronous and far more sensitive to bus jitter —
+          especially when the interface sits behind a hub, dock or USB switch
+          shared with other devices. The generic low-latency rule pushes every
+          ALSA node to `minQuantum`-sized periods, which a contended USB bus
+          cannot refill in time → xruns → crackle/dropouts. When enabled, a
+          dedicated WirePlumber rule matches only `alsa_*.usb-*` nodes (both
+          playback and capture, since the capture node is often the graph
+          driver) and pins the larger `usbPeriodSize`/`usbPeriodNum`/`usbHeadroom`
+          values below. Internal and wired audio keep their low latency.
+        '';
+      };
+
+      usbPeriodSize = mkOption {
+        type = types.int;
+        default = 1024;
+        description = ''
+          ALSA period size (frames) for USB audio nodes when
+          `usbAudioStability` is enabled. ~21ms at 48kHz. Raise to 2048 if a
+          USB interface behind a hub/switch still crackles.
+        '';
+      };
+
+      usbPeriodNum = mkOption {
+        type = types.int;
+        default = 4;
+        description = ''
+          Number of ALSA periods to buffer for USB audio nodes when
+          `usbAudioStability` is enabled. More periods cushion bus jitter from
+          contended hubs at the cost of latency.
+        '';
+      };
+
+      usbHeadroom = mkOption {
+        type = types.int;
+        default = 2048;
+        description = ''
+          ALSA headroom (frames) for USB audio nodes when `usbAudioStability`
+          is enabled. Extra slack absorbs scheduling/bus jitter.
+        '';
+      };
     };
 
     gaming = {
@@ -1364,6 +1412,32 @@ in
                     }
                   }
                 '') cfg.pipewire.forceStereoCards)}
+              ]
+            '')
+          ]) ++ (optionals cfg.pipewire.usbAudioStability [
+            # USB audio interfaces want larger, more resilient buffers than the
+            # aggressive low-latency settings in 52-device-latency.conf. USB is
+            # isochronous and sensitive to bus jitter — doubly so behind a hub,
+            # dock or USB switch shared with other devices. This file sorts after
+            # 52- so its props win for USB nodes. It matches both output and input
+            # (the capture node is frequently the graph driver), leaving internal
+            # and wired ALSA at their low-latency settings.
+            (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/54-usb-audio-latency.conf" ''
+              monitor.alsa.rules = [
+                {
+                  matches = [
+                    { node.name = "~alsa_output.usb-.*" }
+                    { node.name = "~alsa_input.usb-.*" }
+                  ]
+                  actions = {
+                    update-props = {
+                      api.alsa.period-size = ${toString cfg.pipewire.usbPeriodSize}
+                      api.alsa.period-num = ${toString cfg.pipewire.usbPeriodNum}
+                      api.alsa.headroom = ${toString cfg.pipewire.usbHeadroom}
+                      node.latency = "${toString cfg.pipewire.usbPeriodSize}/48000"
+                    }
+                  }
+                }
               ]
             '')
           ]);

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -258,20 +258,25 @@ in
 
       usbPeriodNum = mkOption {
         type = types.int;
-        default = 4;
+        default = 2;
         description = ''
           Number of ALSA periods to buffer for USB audio nodes when
-          `usbAudioStability` is enabled. More periods cushion bus jitter from
-          contended hubs at the cost of latency.
+          `usbAudioStability` is enabled. Keep at 2 (double-buffering): the
+          total ALSA buffer is `usbPeriodSize * usbPeriodNum`, and when the
+          interface runs as a graph *follower* PipeWire resyncs continuously
+          if that buffer sits far above its delay target (~`usbPeriodSize +
+          usbHeadroom`) — which silences output. Raise only alongside headroom.
         '';
       };
 
       usbHeadroom = mkOption {
         type = types.int;
-        default = 2048;
+        default = 1024;
         description = ''
           ALSA headroom (frames) for USB audio nodes when `usbAudioStability`
-          is enabled. Extra slack absorbs scheduling/bus jitter.
+          is enabled. Absorbs scheduling/bus jitter. Keep roughly
+          `usbHeadroom + usbPeriodSize` >= total buffer
+          (`usbPeriodSize * usbPeriodNum`) to avoid follower resync storms.
         '';
       };
     };
@@ -1431,6 +1436,15 @@ in
                   ]
                   actions = {
                     update-props = {
+                      # Timer-based scheduling (NOT IRQ/period-based). USB audio
+                      # behind a hub/dock/switch cannot guarantee period-interrupt
+                      # delivery; in IRQ mode (disable-tsched=true) a single late
+                      # interrupt underruns the stream, and the device cannot
+                      # recover -> permanent XRUN -> the graph loses its driver ->
+                      # total silence, and apps (e.g. browser video) stall waiting
+                      # on a working audio stream. Timer mode wakes PipeWire on its
+                      # own clock, independent of USB IRQ timing.
+                      api.alsa.disable-tsched = false
                       api.alsa.period-size = ${toString cfg.pipewire.usbPeriodSize}
                       api.alsa.period-num = ${toString cfg.pipewire.usbPeriodNum}
                       api.alsa.headroom = ${toString cfg.pipewire.usbHeadroom}

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -247,7 +247,7 @@ in
       };
 
       usbPeriodSize = mkOption {
-        type = types.int;
+        type = types.ints.positive;
         default = 1024;
         description = ''
           ALSA period size (frames) for USB audio nodes when
@@ -257,7 +257,7 @@ in
       };
 
       usbPeriodNum = mkOption {
-        type = types.int;
+        type = types.ints.positive;
         default = 2;
         description = ''
           Number of ALSA periods to buffer for USB audio nodes when
@@ -270,7 +270,7 @@ in
       };
 
       usbHeadroom = mkOption {
-        type = types.int;
+        type = types.ints.unsigned;
         default = 1024;
         description = ''
           ALSA headroom (frames) for USB audio nodes when `usbAudioStability`
@@ -1431,8 +1431,8 @@ in
               monitor.alsa.rules = [
                 {
                   matches = [
-                    { node.name = "~alsa_output.usb-.*" }
-                    { node.name = "~alsa_input.usb-.*" }
+                    { node.name = "~alsa_output\.usb-.*" }
+                    { node.name = "~alsa_input\.usb-.*" }
                   ]
                   actions = {
                     update-props = {


### PR DESCRIPTION
## Problem

ali-desktop's Focusrite Scarlett 2i2 4th Gen audio was crackling, then dying
to total silence. The interface is shared between the PC and the work laptop
via a **USB switch**, so it enumerates ~3 hubs deep behind a Realtek hub it
shares with controllers — its isochronous audio is fragile and cannot be moved
off the hub.

## Root cause (diagnosed live on the machine)

1. **Crackle:** the generic low-latency WirePlumber rule forced `period-size
   256` on every ALSA node, including the USB Scarlett — far too tight for
   USB-through-a-hub → frequent xruns.
2. **Total silence + browser video refusing to play:** the device defaults to
   IRQ/period-based scheduling (`disable-tsched=true`). A USB device behind a
   hub/switch can't guarantee period-interrupt delivery; one late interrupt
   underruns the stream and the device can't recover → permanent `XRUN` → the
   whole PipeWire graph loses its driver → silence, and apps waiting on a
   working audio stream (e.g. Zen video) stall.

## Fix

- New `modules.desktop.pipewire.usbAudioStability` option (default on) adding a
  USB-scoped WirePlumber rule (`54-usb-audio-latency.conf`) matching only
  `alsa_(out|in)put.usb-*` — leaves internal/wired audio low-latency.
- The rule forces **timer-based scheduling** (`api.alsa.disable-tsched=false`)
  so PipeWire wakes on its own clock, independent of USB IRQ timing, plus a
  moderate `period-size 1024` / `period-num 2` / `headroom 1024`.
- udev: pin the Scarlett (`1235:8219`) `power/control=on` + autosuspend off;
  fix a dead 8BitDo rule (`2dc8:3106` → real `3109`) whose autosuspend
  re-enumeration storms were noise on the shared hub.

## Verification

Verified on ali-desktop after `just switch`: `/proc/asound/card3/pcm0p` stays
`RUNNING` with `hw_ptr` advancing continuously at 48 kHz (no XRUN), audio
audible and sustained, on the nix config alone. Three atomic commits, each
independently revertable.

> Note: an unrelated `pnpm-10.29.2` insecure-package eval error exists on the
> current `main` base (via the claude-code home module) — not introduced by
> this PR, which only touches the desktop module + ali-desktop udev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)