### PR TITLE
feat: package token-savior MCP server + wire into Claude Code

### DIFF
--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -100,6 +100,11 @@ in
         DISABLE_AUTOUPDATER = "1";
         DISABLE_ERROR_REPORTING = "1";
         DISABLE_BUG_COMMAND = "1";
+
+        # Token Savior bash-compaction toggles — read by its PreToolUse rewriter
+        # and PostToolUse tool-capture hooks (both default OFF without these).
+        TS_BASH_COMPACT = "1";
+        TS_BASH_REWRITE = "1";
       };
 
       alwaysThinkingEnabled = true;
@@ -130,6 +135,7 @@ in
           "mcp__k8s__*"
 "mcp__terraform__*"
           "mcp__cavemem__*"
+          "mcp__token-savior__*"
           "Bash(git:*)"
           "Bash(GIT_PAGER=cat git:*)"
           "Bash(GIT_DIFF_OPTS= git:*)"
@@ -176,6 +182,23 @@ in
       };
 
       hooks = {
+        # Token Savior bash rewriter — rewrites known commands (git status/diff/log,
+        # tsc, pytest, npm/yarn/pnpm test, cargo test, gh run watch, gh pr list,
+        # docker ps) to compact variants; everything else passes through. Gated
+        # internally by TS_BASH_REWRITE (set in settings.env above).
+        PreToolUse = [
+          {
+            matcher = "Bash";
+            hooks = [
+              {
+                type = "command";
+                command = "${pkgs.token-savior.pythonEnv}/bin/python3 ${pkgs.token-savior}/share/token-savior/hooks/bash_rewriter_hook.py";
+                timeout = 10;
+              }
+            ];
+          }
+        ];
+
         PermissionRequest = [
           {
             matcher = "Bash";
@@ -316,12 +339,24 @@ in
         ];
 
         # Cavemem: captures tool results for memory
+        # Token Savior: captures large tool outputs into its compaction sandbox,
+        # replacing them with expandable references (gated by TS_BASH_COMPACT).
         PostToolUse = [
           {
             hooks = [
               {
                 type = "command";
                 command = "${cavememPkg}/bin/cavemem hook run post-tool-use";
+                timeout = 10;
+              }
+            ];
+          }
+          {
+            matcher = "Bash|WebFetch|Read|Grep|mcp__token-savior__search_codebase|mcp__token-savior__get_function_source|mcp__token-savior__get_class_source";
+            hooks = [
+              {
+                type = "command";
+                command = "${pkgs.token-savior.pythonEnv}/bin/python3 ${pkgs.token-savior}/share/token-savior/hooks/tool_capture_hook.py";
                 timeout = 10;
               }
             ];
@@ -431,6 +466,22 @@ in
       cavemem = {
         command = "${cavememPkg}/bin/cavemem";
         args = [ "mcp" ];
+      };
+
+      # Token Savior: structural code navigation + tool-output compaction.
+      # Named "token-savior" so the PostToolUse capture matcher's
+      # mcp__token-savior__* tool names resolve. Wrapped in bash so
+      # WORKSPACE_ROOTS picks up the session's project dir at launch (mirrors
+      # the obscura wrapper). "optimized" = 15-tool, ~1.5K-token manifest.
+      token-savior = {
+        command = "bash";
+        args = [
+          "-c"
+          ''
+            exec env WORKSPACE_ROOTS="$PWD" TOKEN_SAVIOR_CLIENT=claude-code TOKEN_SAVIOR_PROFILE=optimized \
+              ${pkgs.token-savior}/bin/token-savior
+          ''
+        ];
       };
     };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -40,4 +40,5 @@
   pup-claude = pkgs.callPackage ./pup-claude {};
   llama-models = pkgs.callPackage ./llama-models {};
   superpowers = pkgs.callPackage ./superpowers {};
+  token-savior = pkgs.callPackage ./token-savior { python3Packages = pkgs.unstable.python3Packages; };
 }

--- a/pkgs/token-savior/default.nix
+++ b/pkgs/token-savior/default.nix
@@ -35,7 +35,7 @@ let
     # interpreter that can import token_savior — see passthru.pythonEnv.
     postInstall = ''
       mkdir -p $out/share/token-savior/hooks
-      cp -r hooks/. $out/share/token-savior/hooks/
+      cp hooks/bash_rewriter_hook.py hooks/tool_capture_hook.py $out/share/token-savior/hooks/
     '';
 
     meta = {

--- a/pkgs/token-savior/default.nix
+++ b/pkgs/token-savior/default.nix
@@ -1,0 +1,57 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+let
+  token-savior = python3Packages.buildPythonPackage {
+    pname = "token-savior";
+    version = "4.4.1";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "mibayy";
+      repo = "token-savior";
+      rev = "ff42ef14cc972dad5470e0ca8101e4501e00600f"; # HEAD = v4.4.1
+      hash = "sha256-7qzX4XRPwBjIjBr4Vp1uHI/1ohiVRPHXCpm5aY58Yho=";
+    };
+
+    build-system = [ python3Packages.hatchling ];
+
+    # Core deps + the [mcp] extra (needed to run as an MCP server). The
+    # benchmark/memory-vector/dev extras are intentionally omitted.
+    dependencies = with python3Packages; [
+      pyyaml
+      tree-sitter
+      tree-sitter-grammars.tree-sitter-java
+      tree-sitter-grammars.tree-sitter-ruby
+      watchfiles
+      mcp
+    ];
+
+    pythonImportsCheck = [ "token_savior" ];
+
+    # The repo's hooks/ dir lives outside src/, so buildPythonPackage doesn't
+    # install it. Ship the two bash-compaction hook scripts we wire into Claude
+    # Code declaratively. They are stdlib + lazy `import token_savior` (no
+    # subprocess, no hardcoded interpreter), so they just need to be run by an
+    # interpreter that can import token_savior — see passthru.pythonEnv.
+    postInstall = ''
+      mkdir -p $out/share/token-savior/hooks
+      cp -r hooks/. $out/share/token-savior/hooks/
+    '';
+
+    meta = {
+      description = "MCP server that cuts token usage via structural code navigation and tool-output compaction";
+      homepage = "https://github.com/mibayy/token-savior";
+      license = lib.licenses.mit;
+      mainProgram = "token-savior";
+      platforms = lib.platforms.unix;
+    };
+  };
+in
+token-savior.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    # A python3 with token_savior importable — used as the interpreter for the
+    # bash_rewriter_hook.py / tool_capture_hook.py hooks, which do
+    # `from token_savior... import ...`.
+    pythonEnv = python3Packages.python.withPackages (_: [ token-savior ]);
+  };
+})


### PR DESCRIPTION
## Context

Packages [mibayy/token-savior](https://github.com/mibayy/token-savior) (`token-savior-recall` v4.4.1, MIT) and wires it into the nix-managed Claude Code config the same way the existing MCP servers are. Token Savior is an MCP server that cuts token usage via structural code navigation + tool-output compaction.

## Changes

**`pkgs/token-savior/default.nix`** (new) — `buildPythonPackage` from GitHub, built against **unstable** `python3Packages`. Stable 25.11 is out of range on two deps (`mcp` 1.15 < required 1.25; `tree-sitter-java` 0.25 violates `<0.24`); unstable's `mcp` 1.26 + java 0.23.5 + ruby 0.23.1 all fit pyproject. Uses `buildPythonPackage` (not Application) so the module stays importable by the hooks; `passthru.pythonEnv` exposes an interpreter with `token_savior` on path. Ships the `hooks/` dir (lives outside `src/`) via `postInstall`.

**`pkgs/default.nix`** — exposes `token-savior`, injecting unstable's python set.

**`home/programs/claude-code/default.nix`**:
- `mcpServers.token-savior` — bash-wrapped, `WORKSPACE_ROOTS="$PWD"` per session, `TOKEN_SAVIOR_PROFILE=optimized`. Named `token-savior` so the capture matcher's `mcp__token-savior__*` tools resolve.
- permission `mcp__token-savior__*`
- `settings.env`: `TS_BASH_COMPACT=1` + `TS_BASH_REWRITE=1` (opt-in bash compaction)
- hooks: new `PreToolUse` (Bash rewriter) + appended `PostToolUse` (tool-output capture), both via `pythonEnv`. Replicated declaratively instead of `ts init` (which would fight home-manager). Memory `.sh` hooks excluded — cavemem already owns cross-session memory.

## Verification

- `pkgs.token-savior` builds; `ts`/`token-savior` bins run; `pythonEnv` imports `token_savior` + the exact hook imports.
- Scoped pure eval of `ali-desktop`'s home config: `token-savior` present in `mcpServers`; both hooks + env render with resolved store paths.
- Remaining follow-up after merge: `just switch` on the workstation, confirm `/mcp` shows `token-savior` connected, test a large Bash/Read gets compacted and a `git status`-style command gets rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)