### PR TITLE
fix(base): permit insecure pnpm + drop vesktop

### DIFF
--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -940,7 +940,7 @@ in {
               "video/*" = video;
               "x-scheme-handler/about" = browser;
               "x-scheme-handler/chrome" = browser;
-              "x-scheme-handler/discord" = [ "vesktop.desktop" ];
+              "x-scheme-handler/discord" = [ "discord.desktop" ];
               "x-scheme-handler/etcher" = [ "balena-etcher-electron.desktop" ];
               "x-scheme-handler/ftp" = browser;
               "x-scheme-handler/gitkraken" = [ "GitKraken.desktop" ];

--- a/flake-modules/hosts/ali-framework-laptop/default.nix
+++ b/flake-modules/hosts/ali-framework-laptop/default.nix
@@ -792,7 +792,7 @@ in {
               "video/*" = video;
               "x-scheme-handler/about" = browser;
               "x-scheme-handler/chrome" = browser;
-              "x-scheme-handler/discord" = [ "vesktop.desktop" ];
+              "x-scheme-handler/discord" = [ "discord.desktop" ];
               "x-scheme-handler/etcher" = [ "balena-etcher-electron.desktop" ];
               "x-scheme-handler/ftp" = browser;
               "x-scheme-handler/gitkraken" = [ "GitKraken.desktop" ];

--- a/home/autostart/default.nix
+++ b/home/autostart/default.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }: let
-  # Most autostart entries (steam, discord, vesktop, keybase-gui,
-  # zapzap) are x86_64-only — gate the whole block to skip cleanly on
+  # Most autostart entries (steam, discord, keybase-gui, zapzap) are
+  # x86_64-only — gate the whole block to skip cleanly on
   # aarch64-linux hosts like ali-mba-linux.
   isLinuxX86 = pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64;
 in {
@@ -46,7 +46,6 @@ in {
       ".config/autostart/signal.desktop".source = "${signal-gpu-accel}/share/applications/signal.desktop";
       ".local/share/applications/signal.desktop".source = "${signal-gpu-accel}/share/applications/signal.desktop";
       ".config/autostart/steam.desktop".source = "${pkgs.steam}/share/applications/steam.desktop";
-      ".config/autostart/vesktop.desktop".source = "${pkgs.vesktop}/share/applications/vesktop.desktop";
       ".config/autostart/zapzap.desktop".source = "${pkgs.zapzap}/share/applications/com.rtosta.zapzap.desktop";
       # ".config/autostart/steam.desktop".source = "${steam-autostart-silent}/share/applications/steam-autostart-silent.desktop";
     } else { });

--- a/home/programs/linux-only/niri/module.nix
+++ b/home/programs/linux-only/niri/module.nix
@@ -234,7 +234,6 @@ in {
       window-rule {
           match app-id="^Keybase$"
           match app-id="^discord$"
-          match app-id="^vesktop$"
           match app-id="^ZapZap$"
           match app-id="^signal$"
           default-column-display "tabbed"

--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -292,6 +292,13 @@ in
       nixpkgs = {
         config = {
           allowUnfree = true;
+
+          # signal-desktop builds with pnpm 10.29.2, which nixpkgs marked
+          # insecure (CVE-2026-48995 et al). pnpm is a build-time-only tool
+          # used to assemble node_modules — it is not in the system runtime
+          # closure or PATH — so the CVEs don't affect the running system.
+          # Permit it until nixpkgs ships a non-flagged pnpm for signal.
+          permittedInsecurePackages = [ "pnpm-10.29.2" ];
         };
 
         overlays = [

--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -294,10 +294,23 @@ in
           allowUnfree = true;
 
           # signal-desktop builds with pnpm 10.29.2, which nixpkgs marked
-          # insecure (CVE-2026-48995 et al). pnpm is a build-time-only tool
-          # used to assemble node_modules — it is not in the system runtime
-          # closure or PATH — so the CVEs don't affect the running system.
-          # Permit it until nixpkgs ships a non-flagged pnpm for signal.
+          # insecure (CVE-2026-48995 et al).
+          #
+          # NOTE: this is a GLOBAL eval-time policy — it lets *any* consumer of
+          # this exact pnpm version evaluate/build system-wide without the
+          # insecure-package refusal, not just signal. It does NOT scope to
+          # signal. We accept that because (a) pnpm is a build-time-only tool
+          # for assembling node_modules — never in the system runtime closure
+          # or PATH, so the CVEs don't affect the running system — and (b)
+          # signal-desktop (+ its node-sqlcipher / sticker-creator) is currently
+          # the only pnpm consumer in our closures (vesktop was dropped for this
+          # reason). True per-consumer scoping isn't expressible here; it would
+          # need an overlay clearing meta.knownVulnerabilities on a pnpm threaded
+          # through those derivations.
+          #
+          # REMOVE this permit once nixpkgs ships a non-flagged pnpm for signal
+          # (or pin signal to a build that uses one). Re-check after flake
+          # updates: `nix-store -q --requisites <toplevel.drv> | grep pnpm`.
           permittedInsecurePackages = [ "pnpm-10.29.2" ];
         };
 


### PR DESCRIPTION
## Problem

`just switch` (and any host eval) fails:

```
error: Refusing to evaluate package 'pnpm-10.29.2' ... because it is marked as insecure
```

nixpkgs (pinned `714a5f8`) marked `pnpm-10.29.2` insecure (CVE-2026-48995, -50014..-50017, -50573, -55699). Evaluating `system.build.toplevel` hits the gate. Pre-existing input drift.

## What pulls pnpm-10.29.2

Traced via the host build graph. Two top-level apps build with it (both Electron chat clients):

- **signal-desktop 8.13.0** — direct; also drags `node-sqlcipher-3.3.5` + `signal-desktop-sticker-creator`.
- **vesktop 1.6.5** — direct (Discord client).

Each has a paired `*-pnpm-deps` fixed-output derivation.

## Changes

**1. `fix(base): permit insecure pnpm-10.29.2`** — add it to `nixpkgs.config.permittedInsecurePackages` in `modules/base/default.nix` (DRY across hosts). pnpm is a **build-time-only** tool to assemble `node_modules`; not in the runtime closure or PATH, so the CVEs don't affect the running system. Mirrors the existing `electron-39.8.10` permit. signal-desktop still needs this.

**2. `feat(desktop): drop vesktop`** — vesktop entered the closure only via its autostart `.desktop` reference (never in a packages list). Removed that entry, repointed `x-scheme-handler/discord` from `vesktop.desktop` → `discord.desktop` on both desktop hosts, dropped the niri vesktop window rule. `discord` remains the Discord client. Removes one of the two pnpm consumers.

## Verification

- `nix eval` of `ali-desktop` and `ali-framework-laptop` `system.build.toplevel.drvPath` both succeed (no pnpm refusal).
- `nix-store -q --requisites <toplevel.drv> | grep vesktop` → empty on both hosts (vesktop fully out of closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)