### PR TITLE
token-savior: stats viewers + fix MCP-output capture

### DIFF
--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -14,6 +14,35 @@ let
   cavekitPkg = pkgs.cavekit;
   cavememPkg = pkgs.cavemem;
 
+  # token-savior stats viewers. Both read ~/.local/share/token-savior/*.json,
+  # populated by the MCP nav tools (search_codebase/get_function_source/…), not
+  # the bash-compaction hooks. Profile-independent, zero per-session token cost.
+  tsStatsDashboard = pkgs.writeShellApplication {
+    name = "token-savior-stats";
+    text = ''
+      exec ${pkgs.token-savior}/bin/token-savior-dashboard "$@"
+    '';
+  };
+
+  # Prints the get_usage_stats ASCII view (sparkline + savings table) without
+  # advertising the tool over MCP. Registers $PWD as a project root so
+  # _collect_history() reads that project's cumulative stats file.
+  tsStatsScript = pkgs.writeText "ts-stats.py" ''
+    import os
+    from token_savior import server_state as s
+    from token_savior.server_handlers import stats
+    s._slot_mgr.register_roots([os.environ.get("WORKSPACE_ROOTS", os.getcwd())])
+    for block in stats._hm_get_usage_stats({"daily": True}):
+        print(block.text)
+  '';
+  tsStatsCli = pkgs.writeShellApplication {
+    name = "ts-stats";
+    text = ''
+      exec env TOKEN_SAVIOR_PROFILE=optimized WORKSPACE_ROOTS="''${WORKSPACE_ROOTS:-$PWD}" \
+        ${pkgs.token-savior.pythonEnv}/bin/python3 ${tsStatsScript} "$@"
+    '';
+  };
+
   # Cross-platform sound for the Notification hook (fires when Claude waits
   # for user input). Bypasses the tmux/ghostty bell-propagation chain.
   notifyBell = pkgs.writeShellScript "claude-notify-bell" (
@@ -83,6 +112,11 @@ let
   };
 in
 {
+  # token-savior stats viewers on PATH. Not the whole pkgs.token-savior — that
+  # would also drop the broken token-savior-bench, the server bin, and the
+  # stats-less `ts` onto PATH.
+  home.packages = [ tsStatsDashboard tsStatsCli ];
+
   programs.claude-code = {
     enable = true;
     package = pkgs.master.claude-code;

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -139,6 +139,8 @@ in
         # and PostToolUse tool-capture hooks (both default OFF without these).
         TS_BASH_COMPACT = "1";
         TS_BASH_REWRITE = "1";
+        # Drop _hints/_suggestion blocks from MCP tool results (~30-50 tok/call).
+        TS_NO_HINTS = "1";
       };
 
       alwaysThinkingEnabled = true;
@@ -386,7 +388,13 @@ in
             ];
           }
           {
-            matcher = "Bash|WebFetch|Read|Grep|mcp__token-savior__search_codebase|mcp__token-savior__get_function_source|mcp__token-savior__get_class_source";
+            # Capture large built-in + MCP tool outputs. `mcp__.*` matches every
+            # MCP tool regardless of plugin namespacing (this module ships its
+            # servers as the `claude-code-home-manager` inline plugin, so live
+            # names are `mcp__plugin_claude-code-home-manager_<srv>__<tool>` —
+            # bare `mcp__token-savior__*` never matched). The hook no-ops under
+            # TS_CAPTURE_THRESHOLD_BYTES (4096), so small outputs pass through.
+            matcher = "Bash|WebFetch|Read|Grep|mcp__.*";
             hooks = [
               {
                 type = "command";


### PR DESCRIPTION
## Context
Pursued the question "is token-savior actually doing anything?" Answer: yes — bash-compaction + tool-output capture are the live token savings (the `optimized` profile is upstream's stated Pareto-optimum: −80% tokens/task on the 96-task Opus bench). The memory/vector subsystem reads empty, but that's intentional — `optimized` gates memory hooks, and that subsystem is redundant with the existing cavemem + file memory. Not chased.

Research surfaced one real bug + a couple cheap wins.

## Changes

### `feat`: expose token-savior stats viewers on PATH
The `ts` CLI has no stats subcommand, and the `get_usage_stats` MCP tool is gated out by the `optimized` profile — so savings were unviewable. Adds two on-PATH wrappers:
- **`token-savior-stats`** — stdlib dashboard (`localhost:8921`), reads `~/.local/share/token-savior/*.json`.
- **`ts-stats`** — prints the `get_usage_stats` ASCII view by calling the handler directly. Zero per-session MCP token cost (no profile bump).

Only the two wrappers go on PATH — not the whole package (avoids the broken `token-savior-bench`, the server bin, and the stats-less `ts`).

### `fix`: capture all MCP tool outputs + drop TS hints
The module ships its MCP servers as the `claude-code-home-manager` **inline plugin**, so live tool names are namespaced `mcp__plugin_claude-code-home-manager_<srv>__<tool>`. The capture matcher's bare `mcp__token-savior__*` entries **never matched** — no MCP output was ever sandboxed. Broadened to `mcp__.*` (matches any MCP tool regardless of plugin prefix; no-ops under the 4096-byte threshold so small outputs pass through). Also `TS_NO_HINTS=1` to strip hint/suggestion blocks (~30-50 tok/MCP-call).

## Verification
- `nix build .#nixosConfigurations.ali-desktop...toplevel` — green.
- Generated `settings.json` confirmed: `TS_NO_HINTS=1`, matcher `Bash|WebFetch|Read|Grep|mcp__.*`.
- `ts-stats` + `token-savior-stats` run (sparse data expected — backend only meters MCP nav usage, not the bash hooks).
- Switched + live on `ali-desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)