### PR TITLE
hetzner: cattle CP platform + cattle-replace self-heal

### DIFF
--- a/flake-modules/hetzner-cilium-bootstrap.yaml
+++ b/flake-modules/hetzner-cilium-bootstrap.yaml
@@ -42,15 +42,13 @@ spec:
     endpointRoutes:
       enabled: true
 
-    # Datapath: veth + tproxy (NOT netkit). The L7 proxy (Gateway API / Envoy)
-    # REQUIRES tproxy to redirect to/from Envoy, and tproxy is INCOMPATIBLE with
-    # netkit [Cilium 1.19 docs]. On netkit the Envoy→backend path silently fails
-    # ("upstream connect timeout"; cilium#29864) — our Gateway couldn't reach
-    # Museum. veth + bpf.tproxy is the documented combo for Gateway/Envoy L7
-    # with kube-proxy-replacement + native routing [B19, V4].
+    # Datapath: netkit (perf; kernel 6.18). Cilium does NOT do L7 here — its L7
+    # proxy (tproxy) can't reach same-node backends (cilium#29864), broken on a
+    # single node. Ingress is Envoy Gateway instead (its own Envoy, normal pod
+    # networking) [B19,B21,V4]. So cilium L7/Gateway/Envoy are DISABLED; with no
+    # cilium L7, tproxy is unneeded and netkit is fine.
     bpf:
-      datapathMode: veth
-      tproxy: true
+      datapathMode: netkit
       masquerade: true
       hostLegacyRouting: false
 
@@ -58,22 +56,17 @@ spec:
       enabled: true
       bbr: true
 
-    # Gateway API via hostNetwork Envoy (floating-IP ingress) [V13]. Separate
-    # Envoy DaemonSet so Karpenter sees its per-node reservation.
+    # Cilium L7 OFF — ingress via Envoy Gateway (gatewayClassName eg) [I.gateway].
+    # Leaving cilium's Envoy on would also collide with EG's Envoy on host base-id
+    # 0 / port 443 [B21].
     gatewayAPI:
-      enabled: true
-      hostNetwork:
-        enabled: true
-    l7Proxy: true
+      enabled: false
+    l7Proxy: false
     loadBalancer:
       l7:
-        backend: envoy
-      mode: hybrid
+        backend: disabled
     envoy:
-      enabled: true
-      resources:
-        requests: { cpu: 100m, memory: 128Mi }
-        limits: { cpu: 500m, memory: 512Mi }
+      enabled: false
 
     # Observability — relay yes, UI off (RAM) on a small node.
     hubble:

--- a/flake-modules/hetzner-cilium-bootstrap.yaml
+++ b/flake-modules/hetzner-cilium-bootstrap.yaml
@@ -14,12 +14,13 @@ spec:
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-
-    # kube-proxy replacement [V4]. apiserver is local on the single master;
-    # 127.0.0.1 is reliable (k3s binds *:6443). NB: when cross-cloud workers join
-    # (T10) this must become a shared address (CP Tailscale MagicDNS name) — and
-    # the Hetzner private NIC needs bringing up (currently absent → 10.0.1.10 down).
+    # kube-proxy replacement [V4]. Shared API address reachable by ALL nodes:
+    # the CP's stable Hetzner private IP (tofu-pinned, survives replace) [T10].
+    # k3s binds *:6443; the CP reaches it locally, workers over the private net
+    # (B7 brings up enp7s0=10.0.1.10). Cross-cloud workers (future) would need
+    # the CP Tailscale name instead.
     kubeProxyReplacement: true
-    k8sServiceHost: "127.0.0.1"
+    k8sServiceHost: "10.0.1.10"
     k8sServicePort: "6443"
 
     # IPAM delegated to k3s (--cluster-cidr); avoids a second allocator.

--- a/flake-modules/hetzner-cilium-bootstrap.yaml
+++ b/flake-modules/hetzner-cilium-bootstrap.yaml
@@ -42,11 +42,15 @@ spec:
     endpointRoutes:
       enabled: true
 
-    # Modern datapath (kernel 6.18): netkit + BPF host-routing.
-    # NB: bpf.tproxy is incompatible with datapathMode=netkit (Cilium validate);
-    # netkit handles L7 redirect without it.
+    # Datapath: veth + tproxy (NOT netkit). The L7 proxy (Gateway API / Envoy)
+    # REQUIRES tproxy to redirect to/from Envoy, and tproxy is INCOMPATIBLE with
+    # netkit [Cilium 1.19 docs]. On netkit the Envoy→backend path silently fails
+    # ("upstream connect timeout"; cilium#29864) — our Gateway couldn't reach
+    # Museum. veth + bpf.tproxy is the documented combo for Gateway/Envoy L7
+    # with kube-proxy-replacement + native routing [B19, V4].
     bpf:
-      datapathMode: netkit
+      datapathMode: veth
+      tproxy: true
       masquerade: true
       hostLegacyRouting: false
 

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -366,6 +366,29 @@ let
       '';
     };
 
+    # Bind the Hetzner floating IP to eth0 on the CP so the Cilium Gateway
+    # (hostNetwork Envoy, :443) is reachable through it [V13]. Hetzner routes the
+    # floating IP to the server but the OS must accept it on an interface.
+    systemd.services.floating-ip-bind = {
+      description = "Bind Hetzner floating IP to eth0 (CP ingress) [V13]";
+      after = [ "network-online.target" "cloud-init.service" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
+      script = ''
+        set -euo pipefail
+        for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
+        source /etc/karpenter-node.conf
+        if [ "''${ROLE:-agent}" != "server" ]; then
+          echo "ROLE=''${ROLE:-agent}, not server — skipping floating-ip-bind"; exit 0
+        fi
+        [ -n "''${FLOATING_IP:-}" ] || { echo "no FLOATING_IP in conf"; exit 0; }
+        ${pkgs.iproute2}/bin/ip -4 addr show eth0 | grep -qw "$FLOATING_IP" \
+          || ${pkgs.iproute2}/bin/ip addr add "$FLOATING_IP/32" dev eth0
+        echo "floating IP $FLOATING_IP bound to eth0"
+      '';
+    };
+
     security.sudo.wheelNeedsPassword = lib.mkForce false;
 
     system.stateVersion = "25.11";

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -476,7 +476,13 @@ in
               --image-path "$work/image.raw" \
               --architecture x86 \
               --location nbg1 \
-              --description "nixos-k8s-node amd64 ${version}" \
+              # "talos" tag is load-bearing: karpenter-provider-hetzner v1.0.0
+              # resolves custom SNAPSHOTS only via family=talos, which filters by
+              # `description contains "talos"` [B14]. family only selects the
+              # image — userData/cloud-init is passed verbatim, so our NixOS image
+              # boots normally. The real image is selected by the purpose=k8s-node
+              # label (HCloudNodeClass.imageSelector.selector).
+              --description "talos-compat nixos-k8s-node amd64 ${version}" \
               --labels purpose=k8s-node,os=nixos,arch=amd64
           '';
         };

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -170,19 +170,11 @@ let
         SERVER_ID=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.instance-id')
         LOCATION=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.region')
 
-        # node-ip MUST be a hcloud-known address (CCM rejects others) [B10];
-        # Tailscale is for join only [V3]. Private IP is DHCP-only (not in
-        # metadata) [B16] — read it off the private NIC (10.0.0.0/8), waiting for
-        # B7's DHCP; fall back to public.
-        PUB_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
-        PRIV_IP=""
-        for _ in $(seq 1 30); do
-          PRIV_IP=$(${pkgs.iproute2}/bin/ip -4 -o addr show 2>/dev/null \
-            | ${pkgs.gawk}/bin/awk '$4 ~ /^10\.0\./ {print $4}' | ${pkgs.coreutils}/bin/cut -d/ -f1 | ${pkgs.coreutils}/bin/head -1)
-          [ -n "$PRIV_IP" ] && break
-          sleep 2
-        done
-        NODE_IP="''${PRIV_IP:-$PUB_IP}"
+        # node-ip = PUBLIC: the hcloud CCM (networking.enabled=false) only knows
+        # the server's public address; a private node-ip is rejected and providerID
+        # never set [B10,B17]. Reaching the CP uses the private net via B7 + the
+        # SERVER_ENDPOINT in the join config, independent of node-ip.
+        NODE_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
 
         # Wait for master reachability
         for i in $(seq 1 60); do
@@ -340,7 +332,11 @@ let
           [ -n "$PRIV_IP" ] && break
           sleep 2
         done
-        NODE_IP="''${PRIV_IP:-$PUB_IP}"
+        # node-ip = PUBLIC: the hcloud CCM runs networking.enabled=false so it only
+        # knows the server's public address; a private node-ip is rejected ("node
+        # address ... not valid") and providerID never set [B17]. The private IP is
+        # used for tls-san (below), not node-ip.
+        NODE_IP="$PUB_IP"
 
         # tls-san MUST include the private IP: it is the shared k8sServiceHost
         # [T10] that cilium + workers dial (https://<priv>:6443) — without it in

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -264,8 +264,10 @@ let
         fi
 
         # Open via SSH-answerable prompt (passphrase never stored on the box).
+        # --timeout=0: wait indefinitely for the operator; the default 90s expires
+        # before an operator can SSH in and answer → unlock fails [B13].
         if [ ! -e /dev/mapper/k3s-state ]; then
-          ${pkgs.systemd}/bin/systemd-ask-password "Unlock k3s state volume:" \
+          ${pkgs.systemd}/bin/systemd-ask-password --timeout=0 "Unlock k3s state volume:" \
             | ${pkgs.cryptsetup}/bin/cryptsetup luksOpen "$DEV" k3s-state -
         fi
 

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -171,15 +171,18 @@ let
         LOCATION=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.region')
 
         # node-ip MUST be a hcloud-known address (CCM rejects others) [B10];
-        # Tailscale is for join only [V3]. Prefer private NIC IP if up, else public.
-        PRIV_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')
+        # Tailscale is for join only [V3]. Private IP is DHCP-only (not in
+        # metadata) [B16] — read it off the private NIC (10.0.0.0/8), waiting for
+        # B7's DHCP; fall back to public.
         PUB_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
-        if [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] \
-            && ${pkgs.iproute2}/bin/ip -4 addr show | grep -qw "$PRIV_IP"; then
-          NODE_IP="$PRIV_IP"
-        else
-          NODE_IP="$PUB_IP"
-        fi
+        PRIV_IP=""
+        for _ in $(seq 1 30); do
+          PRIV_IP=$(${pkgs.iproute2}/bin/ip -4 -o addr show 2>/dev/null \
+            | ${pkgs.gawk}/bin/awk '$4 ~ /^10\.0\./ {print $4}' | ${pkgs.coreutils}/bin/cut -d/ -f1 | ${pkgs.coreutils}/bin/head -1)
+          [ -n "$PRIV_IP" ] && break
+          sleep 2
+        done
+        NODE_IP="''${PRIV_IP:-$PUB_IP}"
 
         # Wait for master reachability
         for i in $(seq 1 60); do
@@ -323,24 +326,27 @@ let
 
         # Tailscale IP is for tls-san/join only [V3]. node-ip MUST be a
         # hcloud-known address or the hcloud CCM rejects the node and never sets
-        # providerID ("provided node ip ... not valid") [B10]. Prefer the private
-        # NIC IP when it is actually up (B7); else the public IPv4.
+        # providerID ("provided node ip ... not valid") [B10].
         TS_IP=$(${pkgs.tailscale}/bin/tailscale ip -4 2>/dev/null || true)
-        META=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata)
-        PRIV_IP=$(echo "$META" | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')
-        PUB_IP=$(echo "$META" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
-        if [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] \
-            && ${pkgs.iproute2}/bin/ip -4 addr show | grep -qw "$PRIV_IP"; then
-          NODE_IP="$PRIV_IP"
-        else
-          NODE_IP="$PUB_IP"
-        fi
+        PUB_IP=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata \
+          | ${pkgs.yq-go}/bin/yq '.public-ipv4')
+        # Private IP is DHCP-only — Hetzner metadata does NOT expose it [B16], so
+        # read it off the private NIC (10.0.0.0/8) once B7's DHCP has assigned it.
+        # Wait up to 60s; the iface can lag network-online.target.
+        PRIV_IP=""
+        for _ in $(seq 1 30); do
+          PRIV_IP=$(${pkgs.iproute2}/bin/ip -4 -o addr show 2>/dev/null \
+            | ${pkgs.gawk}/bin/awk '$4 ~ /^10\.0\./ {print $4}' | ${pkgs.coreutils}/bin/cut -d/ -f1 | ${pkgs.coreutils}/bin/head -1)
+          [ -n "$PRIV_IP" ] && break
+          sleep 2
+        done
+        NODE_IP="''${PRIV_IP:-$PUB_IP}"
 
         # tls-san MUST include the private IP: it is the shared k8sServiceHost
         # [T10] that cilium + workers dial (https://<priv>:6443) — without it in
-        # the cert, TLS verification fails. Guard against the yq "null".
+        # the cert, TLS verification fails.
         PRIV_SAN=""
-        [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] && PRIV_SAN="--tls-san $PRIV_IP"
+        [ -n "$PRIV_IP" ] && PRIV_SAN="--tls-san $PRIV_IP"
 
         # SQLite single-node control plane — NO --cluster-init (that is etcd).
         exec ${pkgs.k3s}/bin/k3s server \

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -53,13 +53,10 @@ let
     # Enable Tailscale for cross-cloud networking
     services.tailscale.enable = true;
 
-    # Persistent, size-capped journal. The journal dir is bind-mounted onto the
-    # LUKS volume by k3s-state-volume so logs survive a cattle replace [B25]; cap
-    # the size so it can't fill the (small) state volume.
-    services.journald.extraConfig = ''
-      Storage=persistent
-      SystemMaxUse=500M
-    '';
+    # NB: journald persistence + size cap (Storage=persistent, SystemMaxUse) is
+    # the single authoritative config in modules/hetzner/default.nix — k3s-state-
+    # volume bind-mounts /var/log/journal onto the LUKS volume so those persistent
+    # logs survive a cattle replace [B25].
 
     # Post-quantum SSH key exchange [V12]. mlkem768x25519-sha256 needs
     # OpenSSH 9.9+; keep classical curve25519 as fallback for older clients.
@@ -295,6 +292,11 @@ let
         # operational logs (the ones that explain a death) land on the volume.
         # Size-capped via services.journald (SystemMaxUse) so it can't fill the vol.
         mkdir -p /var/lib/rancher/k3s/journal /var/log/journal
+        # journald only accepts a persistent /var/log/journal owned root:systemd-
+        # journal mode 2755 (setgid); without this it refuses to write there and
+        # the cross-replace logs are lost [PR#154 review].
+        ${pkgs.coreutils}/bin/chgrp systemd-journal /var/lib/rancher/k3s/journal 2>/dev/null || true
+        ${pkgs.coreutils}/bin/chmod 2755 /var/lib/rancher/k3s/journal
         ${pkgs.util-linux}/bin/mountpoint -q /var/log/journal \
           || ${pkgs.util-linux}/bin/mount --bind /var/lib/rancher/k3s/journal /var/log/journal
         ${pkgs.systemd}/bin/systemctl restart systemd-journald 2>/dev/null || true
@@ -424,7 +426,7 @@ let
           echo "ROLE=''${ROLE:-agent}, not server — skipping floating-ip-bind"; exit 0
         fi
         [ -n "''${FLOATING_IP:-}" ] || { echo "no FLOATING_IP in conf"; exit 0; }
-        ${pkgs.iproute2}/bin/ip -4 addr show eth0 | grep -qw "$FLOATING_IP" \
+        ${pkgs.iproute2}/bin/ip -4 addr show eth0 | ${pkgs.gnugrep}/bin/grep -qw "$FLOATING_IP" \
           || ${pkgs.iproute2}/bin/ip addr add "$FLOATING_IP/32" dev eth0
         echo "floating IP $FLOATING_IP bound to eth0"
       '';

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -53,6 +53,14 @@ let
     # Enable Tailscale for cross-cloud networking
     services.tailscale.enable = true;
 
+    # Persistent, size-capped journal. The journal dir is bind-mounted onto the
+    # LUKS volume by k3s-state-volume so logs survive a cattle replace [B25]; cap
+    # the size so it can't fill the (small) state volume.
+    services.journald.extraConfig = ''
+      Storage=persistent
+      SystemMaxUse=500M
+    '';
+
     # Post-quantum SSH key exchange [V12]. mlkem768x25519-sha256 needs
     # OpenSSH 9.9+; keep classical curve25519 as fallback for older clients.
     services.openssh.settings.KexAlgorithms = [
@@ -279,6 +287,17 @@ let
         mkdir -p /var/lib/rancher/k3s/tailscale /var/lib/tailscale
         ${pkgs.util-linux}/bin/mountpoint -q /var/lib/tailscale \
           || ${pkgs.util-linux}/bin/mount --bind /var/lib/rancher/k3s/tailscale /var/lib/tailscale
+
+        # Persist the systemd journal on the LUKS volume so a dead node's logs
+        # survive a VM nuke (cattle replace) — readable after the next boot
+        # ["preserve logs across nukes", B25]. journald flushed early-boot logs to
+        # the ephemeral root pre-unlock; re-open it on the persistent dir so the
+        # operational logs (the ones that explain a death) land on the volume.
+        # Size-capped via services.journald (SystemMaxUse) so it can't fill the vol.
+        mkdir -p /var/lib/rancher/k3s/journal /var/log/journal
+        ${pkgs.util-linux}/bin/mountpoint -q /var/log/journal \
+          || ${pkgs.util-linux}/bin/mount --bind /var/lib/rancher/k3s/journal /var/log/journal
+        ${pkgs.systemd}/bin/systemctl restart systemd-journald 2>/dev/null || true
       '';
     };
 
@@ -442,7 +461,10 @@ let
           sleep 5
         done
 
-        NODE=$(hostname)
+        # `hostname` is NOT in the systemd unit PATH on NixOS (it's in inetutils)
+        # → the bare call exited 127 and the heal never ran [B25 self-heal bugfix].
+        # Read the kernel hostname directly.
+        NODE=$(cat /proc/sys/kernel/hostname)
         INSTANCE_ID=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata \
           | ${pkgs.yq-go}/bin/yq '.instance-id')
         WANT="hcloud://$INSTANCE_ID"

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -170,9 +170,16 @@ let
         SERVER_ID=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.instance-id')
         LOCATION=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.region')
 
-        # Get the node IP — use Tailscale IP if available, otherwise private IP
-        NODE_IP=$(${pkgs.tailscale}/bin/tailscale ip -4 2>/dev/null || \
-          echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')
+        # node-ip MUST be a hcloud-known address (CCM rejects others) [B10];
+        # Tailscale is for join only [V3]. Prefer private NIC IP if up, else public.
+        PRIV_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')
+        PUB_IP=$(echo "$METADATA" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
+        if [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] \
+            && ${pkgs.iproute2}/bin/ip -4 addr show | grep -qw "$PRIV_IP"; then
+          NODE_IP="$PRIV_IP"
+        else
+          NODE_IP="$PUB_IP"
+        fi
 
         # Wait for master reachability
         for i in $(seq 1 60); do
@@ -237,9 +244,17 @@ let
         fi
 
         # Auto-discover the attached Hetzner volume (only non-root block device).
-        DEV=$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1 || true)
+        # On a cattle replace the tofu volume_attachment lands AFTER the server is
+        # created, so the device can be absent for the first seconds of boot —
+        # wait for it instead of failing immediately [B8].
+        DEV=""
+        for i in $(seq 1 60); do
+          DEV=$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1 || true)
+          [ -n "$DEV" ] && break
+          sleep 2
+        done
         if [ -z "$DEV" ]; then
-          echo "No Hetzner volume attached — cannot mount k3s state" >&2
+          echo "No Hetzner volume attached after 120s — cannot mount k3s state" >&2
           exit 1
         fi
 
@@ -255,8 +270,9 @@ let
         fi
 
         mkdir -p /var/lib/rancher/k3s
+        # full path: bare `mount` is not in the unit PATH [B9].
         ${pkgs.util-linux}/bin/mountpoint -q /var/lib/rancher/k3s \
-          || mount /dev/mapper/k3s-state /var/lib/rancher/k3s
+          || ${pkgs.util-linux}/bin/mount /dev/mapper/k3s-state /var/lib/rancher/k3s
       '';
     };
 
@@ -303,9 +319,20 @@ let
           https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml \
           || echo "WARN: Gateway API CRD fetch failed; Gateway inactive until present"
 
+        # Tailscale IP is for tls-san/join only [V3]. node-ip MUST be a
+        # hcloud-known address or the hcloud CCM rejects the node and never sets
+        # providerID ("provided node ip ... not valid") [B10]. Prefer the private
+        # NIC IP when it is actually up (B7); else the public IPv4.
         TS_IP=$(${pkgs.tailscale}/bin/tailscale ip -4 2>/dev/null || true)
-        NODE_IP=''${TS_IP:-$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata \
-          | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')}
+        META=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata)
+        PRIV_IP=$(echo "$META" | ${pkgs.yq-go}/bin/yq '.private-networks[0].ip')
+        PUB_IP=$(echo "$META" | ${pkgs.yq-go}/bin/yq '.public-ipv4')
+        if [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] \
+            && ${pkgs.iproute2}/bin/ip -4 addr show | grep -qw "$PRIV_IP"; then
+          NODE_IP="$PRIV_IP"
+        else
+          NODE_IP="$PUB_IP"
+        fi
 
         # SQLite single-node control plane — NO --cluster-init (that is etcd).
         exec ${pkgs.k3s}/bin/k3s server \
@@ -318,6 +345,7 @@ let
           --disable-kube-proxy \
           --disable=traefik \
           --disable=servicelb \
+          --disable=local-storage \
           --disable-cloud-controller \
           --kubelet-arg=cloud-provider=external \
           --secrets-encryption \

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -479,16 +479,16 @@ in
               ${imagePkg}/grub/boot.img ${imagePkg}/grub/core.img "$work/image.raw" "$lba"
 
             echo "Publishing as Hetzner snapshot (purpose=k8s-node)..."
+            # NB: the "talos" tag in --description is load-bearing —
+            # karpenter-provider-hetzner v1.0.0 resolves custom SNAPSHOTS only via
+            # family=talos, which filters by `description contains "talos"` [B14].
+            # family only selects the image; userData/cloud-init is passed
+            # verbatim, so the NixOS image boots normally. Real image selection is
+            # by the purpose=k8s-node label (HCloudNodeClass.imageSelector.selector).
             hcloud-upload-image upload \
               --image-path "$work/image.raw" \
               --architecture x86 \
               --location nbg1 \
-              # "talos" tag is load-bearing: karpenter-provider-hetzner v1.0.0
-              # resolves custom SNAPSHOTS only via family=talos, which filters by
-              # `description contains "talos"` [B14]. family only selects the
-              # image — userData/cloud-init is passed verbatim, so our NixOS image
-              # boots normally. The real image is selected by the purpose=k8s-node
-              # label (HCloudNodeClass.imageSelector.selector).
               --description "talos-compat nixos-k8s-node amd64 ${version}" \
               --labels purpose=k8s-node,os=nixos,arch=amd64
           '';

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -270,7 +270,25 @@ let
         # full path: bare `mount` is not in the unit PATH [B9].
         ${pkgs.util-linux}/bin/mountpoint -q /var/lib/rancher/k3s \
           || ${pkgs.util-linux}/bin/mount /dev/mapper/k3s-state /var/lib/rancher/k3s
+
+        # Persist Tailscale state on the LUKS volume so the node keeps its
+        # Tailscale identity + IP across a cattle replace [B25]. Without this a
+        # fresh VM re-registers under a new name/IP (master-1 -> master-1-1) and
+        # the kubeconfig server (https://<ts-ip>:6443) breaks. Bind it here,
+        # before tailscaled starts (tailscaled is ordered after this unit).
+        mkdir -p /var/lib/rancher/k3s/tailscale /var/lib/tailscale
+        ${pkgs.util-linux}/bin/mountpoint -q /var/lib/tailscale \
+          || ${pkgs.util-linux}/bin/mount --bind /var/lib/rancher/k3s/tailscale /var/lib/tailscale
       '';
+    };
+
+    # tailscaled state lives on the LUKS volume (bound by k3s-state-volume) so the
+    # Tailscale identity/IP is stable across a cattle replace [B25,V21]. Order it
+    # after the volume is unlocked + bound. On agents k3s-state-volume is a no-op
+    # that exits 0, so this ordering is harmless there (state stays on root).
+    systemd.services.tailscaled = {
+      after = [ "k3s-state-volume.service" ];
+      requires = [ "k3s-state-volume.service" ];
     };
 
     # k3s server bootstrap — single master, SQLite (⊥ --cluster-init/etcd) [V21].
@@ -371,8 +389,12 @@ let
     # floating IP to the server but the OS must accept it on an interface.
     systemd.services.floating-ip-bind = {
       description = "Bind Hetzner floating IP to eth0 (CP ingress) [V13]";
-      after = [ "network-online.target" "cloud-init.service" ];
+      after = [ "network-online.target" "cloud-init.service" "systemd-networkd.service" ];
       wants = [ "network-online.target" ];
+      # PartOf systemd-networkd: a networkd restart flushes addresses (dropping
+      # the floating IP); PartOf makes this unit restart with networkd and re-add
+      # it, so the IP survives networkd restarts without manual re-binding [B25].
+      partOf = [ "systemd-networkd.service" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
       script = ''
@@ -386,6 +408,68 @@ let
         ${pkgs.iproute2}/bin/ip -4 addr show eth0 | grep -qw "$FLOATING_IP" \
           || ${pkgs.iproute2}/bin/ip addr add "$FLOATING_IP/32" dev eth0
         echo "floating IP $FLOATING_IP bound to eth0"
+      '';
+    };
+
+    # Cattle-replace self-heal [B12,B20,B25]. The Node object persists on the LUKS
+    # volume, so a replaced VM boots with the OLD providerID (hcloud://<old-id>)
+    # and stale VolumeAttachments: CCM then can't find the server ("server not
+    # found") and would delete the node, and CSI won't re-attach PVCs. On boot, if
+    # the Node's providerID != this VM's hcloud id, drop the stale Node + its
+    # VolumeAttachments and restart the server so it re-registers cleanly (k3s only
+    # registers at startup). No-op on a normal reboot (providerID matches) or on
+    # agents (role != server).
+    systemd.services.k3s-node-heal = {
+      description = "Heal stale Node/providerID + VolumeAttachments after a cattle replace [B12,B20]";
+      after = [ "k3s-server-bootstrap.service" ];
+      wants = [ "k3s-server-bootstrap.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
+      script = ''
+        set -uo pipefail
+        for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
+        source /etc/karpenter-node.conf
+        if [ "''${ROLE:-agent}" != "server" ]; then
+          echo "ROLE=''${ROLE:-agent}, not server — skipping k3s-node-heal"; exit 0
+        fi
+
+        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+        K="${pkgs.k3s}/bin/k3s kubectl"
+
+        # Wait for the local API to be ready.
+        for i in $(seq 1 60); do
+          $K get --raw=/readyz >/dev/null 2>&1 && break
+          sleep 5
+        done
+
+        NODE=$(hostname)
+        INSTANCE_ID=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata \
+          | ${pkgs.yq-go}/bin/yq '.instance-id')
+        WANT="hcloud://$INSTANCE_ID"
+        HAVE=$($K get node "$NODE" -o jsonpath='{.spec.providerID}' 2>/dev/null || true)
+
+        if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "null" ]; then
+          echo "no instance-id from metadata — skipping heal"; exit 0
+        fi
+        if [ -z "$HAVE" ] || [ "$HAVE" = "$WANT" ]; then
+          echo "providerID ok (have=''${HAVE:-none}) — no heal needed"; exit 0
+        fi
+
+        echo "stale providerID: have=$HAVE want=$WANT — healing"
+        # Stale VolumeAttachments: detached at hcloud when the old VM died, but the
+        # VA still claims attached → CSI won't re-attach [B20]. Delete those on this
+        # node.
+        for va in $($K get volumeattachments \
+          -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName --no-headers 2>/dev/null \
+          | ${pkgs.gawk}/bin/awk -v n="$NODE" '$2==n {print $1}'); do
+          echo "deleting stale VolumeAttachment $va"
+          $K delete volumeattachment "$va" --wait=false || true
+        done
+        # Drop the stale Node so it re-registers fresh (CCM assigns the new
+        # providerID by name). k3s only registers at startup → restart it [B12].
+        $K delete node "$NODE" --wait=false || true
+        echo "restarting k3s-server-bootstrap to re-register the node"
+        ${pkgs.systemd}/bin/systemctl restart --no-block k3s-server-bootstrap.service || true
       '';
     };
 

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -336,12 +336,19 @@ let
           NODE_IP="$PUB_IP"
         fi
 
+        # tls-san MUST include the private IP: it is the shared k8sServiceHost
+        # [T10] that cilium + workers dial (https://<priv>:6443) — without it in
+        # the cert, TLS verification fails. Guard against the yq "null".
+        PRIV_SAN=""
+        [ -n "$PRIV_IP" ] && [ "$PRIV_IP" != "null" ] && PRIV_SAN="--tls-san $PRIV_IP"
+
         # SQLite single-node control plane — NO --cluster-init (that is etcd).
         exec ${pkgs.k3s}/bin/k3s server \
           --token "$K3S_TOKEN" \
           --node-ip "$NODE_IP" \
           --tls-san "$FLOATING_IP" \
           ''${TS_IP:+--tls-san "$TS_IP"} \
+          $PRIV_SAN \
           --flannel-backend=none \
           --disable-network-policy \
           --disable-kube-proxy \

--- a/modules/hetzner/default.nix
+++ b/modules/hetzner/default.nix
@@ -132,7 +132,10 @@ in
 
       firewall = {
         enable = true;
-        allowedTCPPorts = lib.optionals cfg.enableSSH [ 22 ];
+        # 443 = Cilium Gateway (HTTPS via floating IP) [V13]; 22 = SSH. The
+        # hcloud Cloud firewall is the real public gate; this matches it so the
+        # NixOS host doesn't drop 443 on eth0. (harmless on agents — no listener.)
+        allowedTCPPorts = [ 443 ] ++ lib.optionals cfg.enableSSH [ 22 ];
         # Public NIC (eth0) is governed by the Hetzner Cloud firewall (443 + SSH
         # only) [V13]. Intra-cluster traffic rides Tailscale [V3] + the Hetzner
         # private net [B7]; trust those interfaces so k3s API (6443), Cilium

--- a/modules/hetzner/default.nix
+++ b/modules/hetzner/default.nix
@@ -133,14 +133,28 @@ in
       firewall = {
         enable = true;
         allowedTCPPorts = lib.optionals cfg.enableSSH [ 22 ];
+        # Public NIC (eth0) is governed by the Hetzner Cloud firewall (443 + SSH
+        # only) [V13]. Intra-cluster traffic rides Tailscale [V3] + the Hetzner
+        # private net [B7]; trust those interfaces so k3s API (6443), Cilium
+        # (health/VXLAN/Geneve), and node joins flow between CP and workers.
+        trustedInterfaces = [ "tailscale0" "enp7s0" ];
       };
     };
 
     systemd.network = {
       enable = true;
-      wait-online.enable = false; # cloud-init configures the NIC post-boot
-      # No static networks here — cloud-init (Hetzner datasource) is the SOLE
-      # writer of .network files; a custom en* match would race it [B4].
+      wait-online.enable = false; # cloud-init configures the public NIC post-boot
+      # cloud-init (Hetzner datasource) is the SOLE writer for the PUBLIC NIC
+      # (eth0) — never add a match for it here, it races cloud-init [B4,V24].
+      # The PRIVATE NIC (enp7s0) is NOT touched by cloud-init, so we must bring
+      # it up ourselves or 10.0.1.10 never appears [B7]. Match enp* (≠ eth0);
+      # DHCP from the Hetzner private net, no default route (eth0 owns default).
+      networks."10-hetzner-private" = {
+        matchConfig.Name = "enp*";
+        networkConfig.DHCP = "ipv4";
+        dhcpV4Config.UseGateway = false;
+        dhcpV4Config.RouteMetric = 2048;
+      };
     };
 
     # cloud-init-local must reach the metadata service (169.254.169.254) before


### PR DESCRIPTION
Brings the Hetzner self-host platform work onto `main` (it had diverged onto a
feature branch). 11 atomic commits, no desktop/USB changes (main already has those).

## What
- **Cattle control-plane** on k3s: hcloud CCM/CSI (external cloud-provider), LUKS
  state volume with post-boot SSH unlock (`systemd-ask-password --timeout=0`),
  node-ip = public IPv4 (CCM rejects private), private NIC → tls-san/k8sServiceHost.
- **Cilium** netkit + L7 off; ingress via Envoy Gateway (cilium#29864 workaround).
- **Karpenter workers** (private NIC, firewall 443, talos-tag image selector).
- **Cattle-replace self-heal [B25]**: on boot a replaced VM clears its own stale
  Node/providerID + VolumeAttachments and re-registers; floating-IP rebinds on
  networkd restart; Tailscale state persisted on the LUKS volume (stable IP).
- **Heal hostname bug fix [B27]** + **journal persisted on the LUKS volume** so a
  dead node's logs survive a VM nuke (diagnose future deaths).

## Validation
`nix eval` of the toplevel builds on the `main` base. The image VM test
(`nix build .#checks.x86_64-linux.hetzner-karpenter-node`) passes.

## Follow-ups (tracked in terraform/hetzner SPEC.md)
T23 fast-feedback test harness (DRY services + runtime self-heal test), T24
DiskPressure (containerd off the 10GB state volume), T25 karpenter churn, T26
republish+redeploy to bake the self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)