### PR TITLE
test(hetzner): unit-tested cattle-replace self-heal (fast-feedback harness)

### DIFF
--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -10,6 +10,11 @@ let
   # manifests dir by the server bootstrap so the CNI is up before Flux.
   ciliumBootstrapManifest = self + "/flake-modules/hetzner-cilium-bootstrap.yaml";
 
+  # Cattle-replace self-heal logic — a standalone, unit-tested script (the same
+  # file the `hetzner-node-heal` check exercises, so the test tracks reality, no
+  # duplication [B30,V27]). The systemd unit below provides its PATH.
+  healScript = self + "/lib/hetzner-node-heal.sh";
+
   # Shared Hetzner Karpenter node config
   hetznerKarpenterNodeConfig = { modulesPath, lib, pkgs, ... }: {
     modules.hetzner = {
@@ -445,7 +450,11 @@ let
       after = [ "k3s-server-bootstrap.service" ];
       wants = [ "k3s-server-bootstrap.service" ];
       wantedBy = [ "multi-user.target" ];
+      # Declare the script's deps on the unit PATH (NixOS strips defaults — this is
+      # what the unit test mirrors). Kills the bare-command-127 class [B27].
+      path = with pkgs; [ k3s curl yq-go gawk coreutils systemd ];
       serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
+      # Thin wrapper: role-guard, then run the standalone, unit-tested heal script.
       script = ''
         set -uo pipefail
         for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
@@ -453,47 +462,7 @@ let
         if [ "''${ROLE:-agent}" != "server" ]; then
           echo "ROLE=''${ROLE:-agent}, not server — skipping k3s-node-heal"; exit 0
         fi
-
-        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-        K="${pkgs.k3s}/bin/k3s kubectl"
-
-        # Wait for the local API to be ready.
-        for i in $(seq 1 60); do
-          $K get --raw=/readyz >/dev/null 2>&1 && break
-          sleep 5
-        done
-
-        # `hostname` is NOT in the systemd unit PATH on NixOS (it's in inetutils)
-        # → the bare call exited 127 and the heal never ran [B25 self-heal bugfix].
-        # Read the kernel hostname directly.
-        NODE=$(cat /proc/sys/kernel/hostname)
-        INSTANCE_ID=$(${pkgs.curl}/bin/curl -s http://169.254.169.254/hetzner/v1/metadata \
-          | ${pkgs.yq-go}/bin/yq '.instance-id')
-        WANT="hcloud://$INSTANCE_ID"
-        HAVE=$($K get node "$NODE" -o jsonpath='{.spec.providerID}' 2>/dev/null || true)
-
-        if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "null" ]; then
-          echo "no instance-id from metadata — skipping heal"; exit 0
-        fi
-        if [ -z "$HAVE" ] || [ "$HAVE" = "$WANT" ]; then
-          echo "providerID ok (have=''${HAVE:-none}) — no heal needed"; exit 0
-        fi
-
-        echo "stale providerID: have=$HAVE want=$WANT — healing"
-        # Stale VolumeAttachments: detached at hcloud when the old VM died, but the
-        # VA still claims attached → CSI won't re-attach [B20]. Delete those on this
-        # node.
-        for va in $($K get volumeattachments \
-          -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName --no-headers 2>/dev/null \
-          | ${pkgs.gawk}/bin/awk -v n="$NODE" '$2==n {print $1}'); do
-          echo "deleting stale VolumeAttachment $va"
-          $K delete volumeattachment "$va" --wait=false || true
-        done
-        # Drop the stale Node so it re-registers fresh (CCM assigns the new
-        # providerID by name). k3s only registers at startup → restart it [B12].
-        $K delete node "$NODE" --wait=false || true
-        echo "restarting k3s-server-bootstrap to re-register the node"
-        ${pkgs.systemd}/bin/systemctl restart --no-block k3s-server-bootstrap.service || true
+        exec ${pkgs.bash}/bin/bash ${healScript}
       '';
     };
 

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -453,7 +453,9 @@ let
       # Declare the script's deps on the unit PATH (NixOS strips defaults — this is
       # what the unit test mirrors). Kills the bare-command-127 class [B27].
       path = with pkgs; [ k3s curl yq-go gawk coreutils systemd ];
-      serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
+      # conf-wait (≤120s) + readyz-wait (≤300s) exceed systemd's 90s default →
+      # set a generous timeout so the heal isn't killed before it runs [PR#155].
+      serviceConfig = { Type = "oneshot"; RemainAfterExit = true; TimeoutStartSec = "600s"; };
       # Thin wrapper: role-guard, then run the standalone, unit-tested heal script.
       script = ''
         set -uo pipefail

--- a/flake-modules/hetzner-script-tests.nix
+++ b/flake-modules/hetzner-script-tests.nix
@@ -1,0 +1,75 @@
+# Fast UNIT tests (seconds, no VM) for the Hetzner node boot/heal bash logic [V27].
+# Mocks kubectl/curl/yq/systemctl on PATH; PATH deliberately omits inetutils
+# (hostname) + gnugrep to guard the bare-command-127 class [B27].
+#   nix build .#checks.x86_64-linux.hetzner-node-heal
+{ ... }:
+{
+  perSystem = { pkgs, lib, system, ... }:
+    lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
+      checks.hetzner-node-heal =
+        let
+          heal = ../lib/hetzner-node-heal.sh;
+          mocks = pkgs.symlinkJoin {
+            name = "heal-mocks";
+            paths = [
+              # hcloud metadata: emit YAML carrying the scenario instance-id
+              (pkgs.writeShellScriptBin "curl" ''echo "instance-id: ''${MOCK_INSTANCE_ID:-null}"'')
+              # yq '.instance-id' — pull the value out of that YAML
+              (pkgs.writeShellScriptBin "yq" ''${pkgs.gnused}/bin/sed -n 's/^instance-id: //p' '')
+              # systemctl — record the call
+              (pkgs.writeShellScriptBin "systemctl" ''echo "systemctl $*" >> "$CALLLOG"'')
+              # k3s kubectl … — canned reads from env, record mutations
+              (pkgs.writeShellScriptBin "k3s" ''
+                shift   # drop 'kubectl'
+                if [ "$1" = get ] && [ "$2" = --raw=/readyz ]; then exit 0; fi
+                if [ "$1" = get ] && [ "$2" = node ]; then echo "''${MOCK_PROVIDERID:-}"; exit 0; fi
+                if [ "$1" = get ] && [ "$2" = volumeattachments ]; then printf '%b' "''${MOCK_VAS:-}"; exit 0; fi
+                if [ "$1" = delete ]; then echo "kubectl $*" >> "$CALLLOG"; exit 0; fi
+                exit 0
+              '')
+            ];
+          };
+        in
+        pkgs.runCommand "hetzner-node-heal-test"
+          { nativeBuildInputs = [ pkgs.bash pkgs.gnugrep ]; } ''
+          set -euo pipefail
+          # The SCRIPT runs under a constrained node-side PATH: coreutils + gawk +
+          # mocks ONLY — NO inetutils(hostname), NO gnugrep — so a regression to a
+          # bare `hostname`/`grep` fails here in seconds [B27]. The test's own
+          # assertions keep the full builder PATH (grep etc.).
+          run() {
+            env "$@" \
+              PATH="${mocks}/bin:${lib.makeBinPath [ pkgs.coreutils pkgs.gawk ]}" \
+              CALLLOG="$PWD/calllog" KUBECONFIG=/dev/null \
+              HEAL_API_RETRIES=0 NODE_NAME_OVERRIDE=cp ${pkgs.bash}/bin/bash ${heal}
+          }
+
+          echo "## A: providerID matches -> no-op"
+          : > calllog
+          outA=$(run MOCK_INSTANCE_ID=146 MOCK_PROVIDERID=hcloud://146 2>&1) || { echo "exit!=0: $outA"; exit 1; }
+          echo "$outA"
+          grep -q "no heal needed" <<<"$outA" || { echo "FAIL A: expected no-op"; exit 1; }
+          [ ! -s calllog ] || { echo "FAIL A: no-op mutated: $(cat calllog)"; exit 1; }
+
+          echo "## B: stale providerID -> heal (own VA + node + restart)"
+          : > calllog
+          outB=$(run MOCK_INSTANCE_ID=999 MOCK_PROVIDERID=hcloud://OLD \
+                     MOCK_VAS="csi-mine cp\ncsi-other worker\n" 2>&1) || { echo "exit!=0: $outB"; exit 1; }
+          echo "$outB"
+          grep -q "delete volumeattachment csi-mine" calllog || { echo "FAIL B: own VA not deleted"; cat calllog; exit 1; }
+          ! grep -q "csi-other" calllog || { echo "FAIL B: other node's VA touched"; exit 1; }
+          grep -q "delete node cp" calllog || { echo "FAIL B: stale node not deleted"; cat calllog; exit 1; }
+          grep -q "restart .*k3s-server-bootstrap" calllog || { echo "FAIL B: bootstrap not restarted"; cat calllog; exit 1; }
+
+          echo "## C: no instance-id -> skip"
+          : > calllog
+          outC=$(run MOCK_INSTANCE_ID=null MOCK_PROVIDERID=hcloud://OLD 2>&1) || { echo "exit!=0: $outC"; exit 1; }
+          echo "$outC"
+          grep -q "no instance-id" <<<"$outC" || { echo "FAIL C: expected skip"; exit 1; }
+          [ ! -s calllog ] || { echo "FAIL C: skip mutated"; exit 1; }
+
+          echo "ALL PASS"
+          touch $out
+        '';
+    };
+}

--- a/lib/hetzner-node-heal.sh
+++ b/lib/hetzner-node-heal.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Cattle-replace self-heal [B12,B20,B25]. On boot, a replaced VM's persisted Node
+# object carries the OLD providerID + stale VolumeAttachments → CCM can't find the
+# server and CSI won't re-attach. If the Node's providerID != this VM's hcloud id,
+# drop the stale Node + its VolumeAttachments and restart the server so it
+# re-registers cleanly. No-op on a normal reboot (providerID matches).
+#
+# PATH-driven (no hardcoded store paths) so the systemd unit's `path` provides the
+# real tools in prod and the unit test can shim mocks. Externals are overridable
+# via env for unit testing:
+#   NODE_NAME_OVERRIDE  node name        (default: kernel hostname)
+#   METADATA_URL        hcloud metadata  (default: hcloud link-local)
+#   KUBECONFIG          kubeconfig       (default: k3s.yaml)
+#   HEAL_API_RETRIES    readyz wait iters (default 60; tests set 0 to skip)
+set -uo pipefail
+
+NODE="${NODE_NAME_OVERRIDE:-$(cat /proc/sys/kernel/hostname)}"
+METADATA_URL="${METADATA_URL:-http://169.254.169.254/hetzner/v1/metadata}"
+export KUBECONFIG="${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}"
+
+kc() { k3s kubectl "$@"; }
+
+# Wait for the local API to be ready (skippable in tests).
+for _ in $(seq 1 "${HEAL_API_RETRIES:-60}"); do
+  kc get --raw=/readyz >/dev/null 2>&1 && break
+  sleep 5
+done
+
+INSTANCE_ID=$(curl -s "$METADATA_URL" | yq '.instance-id')
+WANT="hcloud://$INSTANCE_ID"
+HAVE=$(kc get node "$NODE" -o jsonpath='{.spec.providerID}' 2>/dev/null || true)
+
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "null" ]; then
+  echo "no instance-id from metadata — skipping heal"; exit 0
+fi
+if [ -z "$HAVE" ] || [ "$HAVE" = "$WANT" ]; then
+  echo "providerID ok (have=${HAVE:-none}) — no heal needed"; exit 0
+fi
+
+echo "stale providerID: have=$HAVE want=$WANT — healing"
+# Stale VolumeAttachments: detached at hcloud when the old VM died, but the VA
+# still claims attached → CSI won't re-attach [B20]. Delete those on this node.
+for va in $(kc get volumeattachments \
+  -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName --no-headers 2>/dev/null \
+  | awk -v n="$NODE" '$2==n {print $1}'); do
+  echo "deleting stale VolumeAttachment $va"
+  kc delete volumeattachment "$va" --wait=false || true
+done
+# Drop the stale Node so it re-registers fresh (CCM assigns the new providerID by
+# name). k3s only registers at startup → restart it [B12].
+kc delete node "$NODE" --wait=false || true
+echo "restarting k3s-server-bootstrap to re-register the node"
+systemctl restart --no-block k3s-server-bootstrap.service || true

--- a/lib/hetzner-node-heal.sh
+++ b/lib/hetzner-node-heal.sh
@@ -12,7 +12,12 @@
 #   METADATA_URL        hcloud metadata  (default: hcloud link-local)
 #   KUBECONFIG          kubeconfig       (default: k3s.yaml)
 #   HEAL_API_RETRIES    readyz wait iters (default 60; tests set 0 to skip)
-set -uo pipefail
+#
+# set -e (with pipefail): a bare-command failure inside a $(...) aborts the script
+# instead of silently yielding empty + falling through to "no heal needed" — so a
+# regression to a missing command surfaces (and the PATH-constrained unit test
+# catches it). Idempotent mutations below keep explicit `|| true`.
+set -euo pipefail
 
 NODE="${NODE_NAME_OVERRIDE:-$(cat /proc/sys/kernel/hostname)}"
 METADATA_URL="${METADATA_URL:-http://169.254.169.254/hetzner/v1/metadata}"


### PR DESCRIPTION
First slice of the reliability test pyramid (terraform/hetzner SPEC T23, V27): a
**fast unit test** (seconds, no qemu) for the boot self-heal logic, so the
bare-command-127 class [B27] is caught locally instead of in a prod cattle-replace.

## What
- Extract the cattle-replace self-heal into a standalone, PATH-driven script
  `lib/hetzner-node-heal.sh` (externals env-injectable for testing).
- New flake check `hetzner-node-heal`: runs it with mocked kubectl/curl/yq/
  systemctl and asserts — no-op on matching providerID, full heal (own VA +
  node delete + bootstrap restart) on stale, skip on missing metadata. The
  script's PATH deliberately omits `hostname`/`grep` so a regression to a bare
  command fails the test in seconds.
- `k3s-node-heal.service` runs that **same** script (no duplicate copy [B30]) and
  declares its deps via systemd `path` — the idiomatic fix for the stripped unit
  PATH (root cause of B27 + the Copilot grep/hostname findings).

## Validation
`nix build .#checks.x86_64-linux.hetzner-node-heal` → ALL PASS. Image toplevel evals.

## Next (same branch / follow-ups)
Extend the same pattern to the other bootstrap scripts + a runtime VM self-heal
subtest; then T24 (DiskPressure) / T25 (karpenter churn) / T26 (baked redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)