### PR TITLE
fix(hetzner): node image reliability — bare-cmd class + ext4 auto-grow

### DIFF
--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -128,10 +128,13 @@ let
           exit 0
         fi
 
-        # Bring up Tailscale
+        # Bring up Tailscale. `hostname` is not in the stripped unit PATH (it's in
+        # inetutils) → bare `$(hostname)` exits 127 and yields an empty hostname
+        # (masked here only because tailscale then falls back to the OS hostname)
+        # [B27 class]. Read the kernel hostname directly.
         ${pkgs.tailscale}/bin/tailscale up \
           --auth-key="$TAILSCALE_AUTH_KEY" \
-          --hostname="$(hostname)"
+          --hostname="$(cat /proc/sys/kernel/hostname)"
 
         # Wait for Tailscale IP assignment
         for i in $(seq 1 30); do

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -129,12 +129,11 @@ let
         fi
 
         # Bring up Tailscale. `hostname` is not in the stripped unit PATH (it's in
-        # inetutils) → bare `$(hostname)` exits 127 and yields an empty hostname
-        # (masked here only because tailscale then falls back to the OS hostname)
-        # [B27 class]. Read the kernel hostname directly.
+        # inetutils) → bare `$(hostname)` exits 127 [B27 class]. Read the kernel
+        # hostname via a bash builtin redirection (no external `cat` either).
         ${pkgs.tailscale}/bin/tailscale up \
           --auth-key="$TAILSCALE_AUTH_KEY" \
-          --hostname="$(cat /proc/sys/kernel/hostname)"
+          --hostname="$(< /proc/sys/kernel/hostname)"
 
         # Wait for Tailscale IP assignment
         for i in $(seq 1 30); do

--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -284,6 +284,13 @@ let
         ${pkgs.util-linux}/bin/mountpoint -q /var/lib/rancher/k3s \
           || ${pkgs.util-linux}/bin/mount /dev/mapper/k3s-state /var/lib/rancher/k3s
 
+        # Grow ext4 to the LUKS mapping (idempotent — no-op if already at size).
+        # luksOpen maps the full backing device, so when the tofu volume is grown
+        # [T24/B28] a fresh boot opens at the new size and this expands the fs —
+        # no manual cryptsetup/resize2fs. Stops the containerd image store filling
+        # the (previously 10G) state volume → DiskPressure → Museum evictions [B28].
+        ${pkgs.e2fsprogs}/bin/resize2fs /dev/mapper/k3s-state 2>/dev/null || true
+
         # Persist Tailscale state on the LUKS volume so the node keeps its
         # Tailscale identity + IP across a cattle replace [B25]. Without this a
         # fresh VM re-registers under a new name/IP (master-1 -> master-1-1) and

--- a/flake-modules/hetzner-tests.nix
+++ b/flake-modules/hetzner-tests.nix
@@ -97,9 +97,11 @@ in
                 exit 0
               fi
 
+              # Mirror the image (bash builtin read, no bare hostname/cat) — until
+              # the DRY service-module extraction [B30/T23] removes this copy.
               ${pkgs.tailscale}/bin/tailscale up \
                 --auth-key="$TAILSCALE_AUTH_KEY" \
-                --hostname="$(hostname)"
+                --hostname="$(< /proc/sys/kernel/hostname)"
 
               for i in $(seq 1 30); do
                 TS_IP=$(${pkgs.tailscale}/bin/tailscale ip -4 2>/dev/null || true)

--- a/lib/hetzner-node-heal.sh
+++ b/lib/hetzner-node-heal.sh
@@ -19,7 +19,7 @@
 # catches it). Idempotent mutations below keep explicit `|| true`.
 set -euo pipefail
 
-NODE="${NODE_NAME_OVERRIDE:-$(cat /proc/sys/kernel/hostname)}"
+NODE="${NODE_NAME_OVERRIDE:-$(< /proc/sys/kernel/hostname)}"  # bash builtin read, no external `cat`
 METADATA_URL="${METADATA_URL:-http://169.254.169.254/hetzner/v1/metadata}"
 export KUBECONFIG="${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}"
 


### PR DESCRIPTION
Two small, related Hetzner node-image reliability fixes (both eval-validated; unit test green):

1. **Close the bare-command-127 class** — tailscale-bootstrap (+ heal + test) read
   the kernel hostname via bash `$(< /proc/sys/kernel/hostname)` instead of bare
   `hostname`/`cat` (not in the stripped unit PATH) [B27].
2. **DiskPressure auto-grow** [T24/B28] — `resize2fs` the LUKS-mapped ext4 on boot
   (idempotent); paired with the state volume 10→40GiB bump (terraform). luksOpen
   maps the full device, so the fs expands on the next replace with no manual
   steps. Fixes the containerd image store filling the 10G volume → Museum evictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)