### PR TITLE
feat(hetzner): auto-clean ghost pods left by cattle-replace

### DIFF
--- a/flake-modules/hetzner-script-tests.nix
+++ b/flake-modules/hetzner-script-tests.nix
@@ -59,6 +59,8 @@
           grep -q "delete volumeattachment csi-mine" calllog || { echo "FAIL B: own VA not deleted"; cat calllog; exit 1; }
           ! grep -q "csi-other" calllog || { echo "FAIL B: other node's VA touched"; exit 1; }
           grep -q "delete node cp" calllog || { echo "FAIL B: stale node not deleted"; cat calllog; exit 1; }
+          grep -q "delete pods -A --field-selector=status.phase=Failed,spec.nodeName=cp" calllog || { echo "FAIL B: Failed ghost pods not swept (scoped to node)"; cat calllog; exit 1; }
+          grep -q "delete pods -A --field-selector=status.phase=Succeeded,spec.nodeName=cp" calllog || { echo "FAIL B: Succeeded ghost pods not swept (scoped to node)"; cat calllog; exit 1; }
           grep -q "restart .*k3s-server-bootstrap" calllog || { echo "FAIL B: bootstrap not restarted"; cat calllog; exit 1; }
 
           echo "## C: no instance-id -> skip"

--- a/lib/hetzner-node-heal.sh
+++ b/lib/hetzner-node-heal.sh
@@ -54,5 +54,14 @@ done
 # Drop the stale Node so it re-registers fresh (CCM assigns the new providerID by
 # name). k3s only registers at startup → restart it [B12].
 kc delete node "$NODE" --wait=false || true
+# Ghost pods: a replace leaves terminated (Failed/Succeeded) pod objects from the
+# old generation. ReplicaSet controllers ignore terminal pods and pod-GC only
+# sweeps past --terminated-pod-gc-threshold, so they linger forever. Clear them
+# here (the threshold backstop in k3s-server bounds any late stragglers).
+# Scoped to THIS node (spec.nodeName) so other nodes' terminal pods keep their
+# debug signal — the ghosts carry this node's name (the hostname is reused).
+echo "sweeping terminated (Failed/Succeeded) ghost pods on $NODE left by the replace"
+kc delete pods -A --field-selector=status.phase=Failed,spec.nodeName="$NODE" --wait=false || true
+kc delete pods -A --field-selector=status.phase=Succeeded,spec.nodeName="$NODE" --wait=false || true
 echo "restarting k3s-server-bootstrap to re-register the node"
 systemctl restart --no-block k3s-server-bootstrap.service || true

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -329,6 +329,7 @@
           --disable=local-storage \
           --disable-cloud-controller \
           --kubelet-arg=cloud-provider=external \
+          --kube-controller-manager-arg=terminated-pod-gc-threshold=10 \
           --secrets-encryption \
           --cluster-cidr=10.42.0.0/16 \
           --service-cidr=10.43.0.0/16 \


### PR DESCRIPTION
## What

After a CP cattle-replace, terminated (Failed/Succeeded) pod objects from the old node generation linger forever — ReplicaSet controllers ignore terminal pods and pod-GC only sweeps past \`--terminated-pod-gc-threshold\` (k3s default 12500 ≈ never). Observed 4 ghosts surviving the 2026-06-29 replace.

Two complementary mechanisms, both baked into the snapshot (GitOps, no live mutation), taking effect on the next normal replace:

1. **Self-heal sweep** (\`lib/hetzner-node-heal.sh\`) — the boot-time heal already clears the stale Node + VolumeAttachments for the replace event; add a cluster-wide terminated-pod sweep in the same branch. Precise, runs exactly when ghosts are born.
2. **GC threshold backstop** (\`terminated-pod-gc-threshold=10\`) — bounds any ghost that turns terminal *after* the heal runs (e.g. a leftover replica the scheduler later rejects with NodeAffinity). Keeps recent terminal pods for debugging while capping clutter.

## Test

- Unit check \`hetzner-node-heal\` extended: scenario B now asserts both the Failed and Succeeded sweeps fire. Green.
- VM test \`hetzner-karpenter-node\` running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)