### PR TITLE
fix(hetzner): disable automatic nix-gc on the cattle node (wedge root cause)

### DIFF
--- a/modules/hetzner/default.nix
+++ b/modules/hetzner/default.nix
@@ -191,10 +191,17 @@ in
     nix = {
       extraOptions = "experimental-features = nix-command flakes";
 
+      # Automatic GC is DISABLED on this cattle/ephemeral-root appliance node.
+      # The node boots fresh from a baked snapshot and is never rebuilt in place
+      # (config changes ship as a new snapshot + cattle-replace), so no old
+      # generations accumulate — auto-gc has zero upside here. It is also a known
+      # wedge risk: GC roots only cover current-system's closure, so a store path
+      # referenced only at runtime (e.g. k3s/containerd-extracted runc, a lazily
+      # activated unit) can be collected out from under the running system →
+      # "binary vanished, exec fails" lockup (observed 2026-06-28). Reclaim space
+      # by replacing the node, not by GC.
       gc = {
-        automatic = true;
-        dates = "weekly";
-        options = "--delete-older-than 30d";
+        automatic = false;
       };
 
       settings = {


### PR DESCRIPTION
## Root cause

Investigating the 2026-06-28 control-plane wedge (runc + sshd "vanished" — running processes survived but new \`exec\` failed, so no SSH and no container starts). That symptom is the textbook signature of an **in-use Nix store path garbage-collected out from under the running system**.

The Hetzner node had **`nix.gc.automatic = true`** (weekly timer, confirmed live: `nix-gc.timer` enabled, next fire 2026-07-06). GC roots only protect `current-system`'s closure — anything referenced only at runtime (k3s/containerd-extracted `runc`, a lazily activated unit) is fair game.

## Why disabling is correct (not just a workaround)

This node is a **cattle / ephemeral-root appliance**: it boots fresh from a baked snapshot and is *never* rebuilt in place (config changes ship as a new snapshot + cattle-replace). No old generations ever accumulate, so automatic GC has **zero upside** — only the eviction risk. Reclaim space by replacing the node.

## Change

`modules/hetzner/default.nix`: `nix.gc.automatic = false` (with rationale comment). The module is enable-gated and only the cattle Karpenter node turns it on, so nothing else is affected.

## Verify

```
nix eval .#nixosConfigurations.hetzner-karpenter-node-amd64.config.nix.gc.automatic
# => false
```

Takes effect on the next snapshot republish + replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)