### PR TITLE
harden(hetzner): boot-service robustness + niks3 queue perms

### DIFF
--- a/flake-modules/hetzner-images.nix
+++ b/flake-modules/hetzner-images.nix
@@ -40,7 +40,9 @@ let
       set -eu; set -f
       echo "$OUT_PATHS" | tr ' ' '\n' >> /var/tmp/niks3-queue
     '';
-    systemd.tmpfiles.rules = [ "f /var/tmp/niks3-queue 0666 root root -" ];
+    # 0600 not 0666: the post-build-hook runs as root, so a world-writable queue
+    # only lets an unprivileged process (or a pod with hostPath) inject store paths.
+    systemd.tmpfiles.rules = [ "f /var/tmp/niks3-queue 0600 root root -" ];
 
     boot.kernel.sysctl = {
       # Cilium Envoy: allow binding to privileged ports (80/443) for Gateway API hostNetwork mode

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -19,6 +19,14 @@
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # conf-wait (≤120s) + TS-IP-wait (≤60s) + `tailscale up` can exceed
+        # systemd's 90s default → the unit would be KILLED mid-bootstrap and every
+        # downstream service (agent/server bootstrap require this) would block,
+        # wedging the node after a replace. Generous timeout + retry on transient
+        # `tailscale up` failures (auth rate-limit, tailscaled socket lag).
+        TimeoutStartSec = "300s";
+        Restart = "on-failure";
+        RestartSec = "15s";
       };
 
       script = ''
@@ -377,7 +385,17 @@
       # it, so the IP survives networkd restarts without manual re-binding [B25].
       partOf = [ "systemd-networkd.service" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = { Type = "oneshot"; RemainAfterExit = true; };
+      # conf-wait (≤120s) > systemd 90s default → set a generous timeout so it
+      # isn't killed before binding. On a networkd-triggered restart (PartOf) eth0
+      # may still be reconfiguring → `ip addr add` fails under set -e; retry so the
+      # floating IP (CP ingress) isn't left unbound until manual intervention [B25].
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        TimeoutStartSec = "180s";
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
       script = ''
         set -euo pipefail
         for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
@@ -412,8 +430,12 @@
       # set a generous timeout so the heal isn't killed before it runs [PR#155].
       serviceConfig = { Type = "oneshot"; RemainAfterExit = true; TimeoutStartSec = "600s"; };
       # Thin wrapper: role-guard, then run the standalone, unit-tested heal script.
+      # set -e so a failed `source` (conf genuinely absent) fails the unit loudly
+      # instead of silently defaulting ROLE=agent and skipping the server heal. The
+      # heal runs after k3s-server-bootstrap, which already sourced the conf, so the
+      # file is present in the normal path.
       script = ''
-        set -uo pipefail
+        set -euo pipefail
         for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
         source /etc/karpenter-node.conf
         if [ "''${ROLE:-agent}" != "server" ]; then


### PR DESCRIPTION
Hardening batch from a parallel audit (4 read-only audit agents across ephemeral-vs-LUKS secrets, systemd robustness, k3s config, and terraform/firewall). Only LOW-risk, high-value fixes baked here; the rest are tracked separately.

## Boot-service robustness (the wedge-risk class)

Both `tailscale-bootstrap` and `floating-ip-bind` are `Type=oneshot` with conf-wait loops that can exceed systemd's **90s default `TimeoutStartSec`** → the unit gets killed mid-bootstrap. For `tailscale-bootstrap` that's fatal: agent + server bootstrap both `require` it, so the whole node wedges after a replace.

- `tailscale-bootstrap`: `TimeoutStartSec=300s` (conf 120s + TS-IP 60s + `tailscale up`) + `Restart=on-failure` (retry transient `tailscale up` rate-limits).
- `floating-ip-bind`: `TimeoutStartSec=180s` + `Restart=on-failure` (retry a networkd-`PartOf` rebind that races eth0 reconfig → CP ingress IP otherwise left unbound).
- `k3s-node-heal` wrapper: `set -uo` → `set -euo` so a failed `source` fails loudly instead of silently defaulting `ROLE=agent` and skipping the server heal.

## Hygiene

- `/var/tmp/niks3-queue`: `0666` → `0600` (root writes it; world-writable let any unprivileged process / hostPath pod inject store paths).

## Validation

- `nix eval` of the image config: builds.
- VM test `hetzner-karpenter-node`: running.

## Follow-ups (separate, not in this PR)

- k3s API hardening flags (anonymous-auth, audit log, TLS pinning) — verifying against k3s defaults first.
- Metadata-service egress lockdown for pods (B32) — better as a Cilium policy (eBPF datapath) than host nftables; GitOps, applies live.
- Terraform: `rebuild_protection` on the CP server; worker firewall split; IPv6 ingress review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)