### PR TITLE
fix(hetzner): retry LUKS unlock on wrong passphrase (failed unit wedged CP boot) [B34]

### DIFF
--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -226,10 +226,24 @@
         # Open via SSH-answerable prompt (passphrase never stored on the box).
         # --timeout=0: wait indefinitely for the operator; the default 90s expires
         # before an operator can SSH in and answer → unlock fails [B13].
-        if [ ! -e /dev/mapper/k3s-state ]; then
-          ${pkgs.systemd}/bin/systemd-ask-password --timeout=0 "Unlock k3s state volume:" \
-            | ${pkgs.cryptsetup}/bin/cryptsetup luksOpen "$DEV" k3s-state -
-        fi
+        #
+        # RETRY on a wrong passphrase [B34]: a typo'd answer makes `cryptsetup
+        # luksOpen` exit non-zero. Without this loop, `set -e` would then FAIL the
+        # whole unit — and because k3s-server-bootstrap `Requires=`/`After=` this
+        # one, systemd cancels it and does NOT re-run it when the operator unlocks
+        # on a later attempt → the CP silently never starts (needs a manual
+        # `systemctl start k3s-server-bootstrap`). Looping keeps the unit in
+        # `activating` (TimeoutStartSec=infinity) and re-prompts until the volume
+        # opens, so the dependency chain stays intact. The pipeline is the `until`
+        # condition, so its non-zero exit is exempt from `set -e` (no abort).
+        until [ -e /dev/mapper/k3s-state ]; do
+          if ${pkgs.systemd}/bin/systemd-ask-password --timeout=0 "Unlock k3s state volume:" \
+               | ${pkgs.cryptsetup}/bin/cryptsetup luksOpen "$DEV" k3s-state -; then
+            break
+          fi
+          echo "luksOpen failed (wrong passphrase?) — re-prompting" >&2
+          sleep 1
+        done
 
         mkdir -p /var/lib/rancher/k3s
         # full path: bare `mount` is not in the unit PATH [B9].


### PR DESCRIPTION
## Bug (hit live during the snapshot-403220410 replace)

The operator typo'd the LUKS passphrase on the first prompt. `cryptsetup luksOpen` exited non-zero → with `set -euo pipefail` that **failed the `k3s-state-volume` unit**. Since `k3s-server-bootstrap` `Requires=`/`After=` it, systemd cancelled the bootstrap and did **not** re-run it when the volume was unlocked on the retry. Result: volume mounted, node-password on LUKS, zero hash-mismatch — but `k3s-server-bootstrap` sat `inactive (dead)`, API down, **no node**, until a manual `systemctl start k3s-server-bootstrap`.

A wrong passphrase should never need manual recovery.

## Fix

Wrap the unlock in `until [ -e /dev/mapper/k3s-state ]; do … done`, with the `systemd-ask-password | cryptsetup luksOpen` pipeline as an `if` condition (so its non-zero exit is exempt from `set -e`). A wrong passphrase re-prompts; the unit stays `activating` (`TimeoutStartSec=infinity`) until the volume opens; the dependency chain to `k3s-server-bootstrap` stays intact. Idempotent (skips if already open).

## Validation
- `nix eval` toplevel: builds (NixOS runs `bash -n` on unit scripts at build time).
- VM test `hetzner-karpenter-node`: running.

Follow-up: a server-role VM subtest that mocks a wrong-then-right unlock would lock this in (same spirit as the deferred runtime self-heal subtest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)