### PR TITLE
Slim Claude Code per-session/subagent context baseline

### DIFF
--- a/.claude/skills/minecraft-modpack-packaging/SKILL.md
+++ b/.claude/skills/minecraft-modpack-packaging/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: minecraft-modpack-packaging
+description: How this repo packages Minecraft modpacks as Nix-built OCI images
+  (create-sky-colonies-server vanilla pattern, create-arkana-aeronautics-server
+  manifest+bisection pattern). Use when working on pkgs/create-*-server,
+  pkgs/minecraft-modpack-tools, the bisect loop, mod-version bumping
+  (find-mod-bumps), arkana-mods*.nix / arkana-groups.nix / overlays.nix, dep-tree,
+  CurseForge/NeoForge/Create version floors, or any Minecraft modpack server crash
+  triage in this repo.
+---
+
+# Minecraft modpack server packaging
+
+Two patterns ship Minecraft modpacks as Nix-built OCI images:
+
+- `pkgs/create-sky-colonies-server` — vanilla pattern. The publisher releases a "Server Pack" zip; we `fetchurl` it and overlay perf mods + JVM args + entrypoint. Used for any modpack whose publisher ships a pre-installed server tree.
+- `pkgs/create-arkana-aeronautics-server` — manifest-driven pattern with bisection. Modpack ships only a CurseForge "manifest pack" (manifest.json + overrides/, no jars), so we resolve every mod via cfwidget+mediafilez into `arkana-mods.nix`, run the NeoForge installer at first boot to populate `/data/libraries`, and bisect mod groups to find what coexists.
+
+The bisection workflow is the part worth knowing. `pkgs/minecraft-modpack-tools` ships generic helpers (`dep-tree` is the only one currently); `pkgs/create-arkana-aeronautics-server` keeps the modpack-specific pieces (`group-classifier.py`, `bisect.sh`, `generate-arkana-mods.sh`).
+
+## When to bisect
+
+Whenever a modpack's overlay (extra mods we add on top) requires a Create / NeoForge / library version newer than what the base modpack ships. Bumping a single core lib often cascades into mod-construction or registry-init NPEs across 5-15 unrelated mods that were tuned to the older API. Bisecting identifies which Arkana mods stay compatible with the bumped floor — keep those, disable the rest.
+
+## The four files that drive composition
+
+- `arkana-mods.nix` — auto-generated from the modpack's manifest.json. **Don't hand-edit.** Regenerate with `generate-arkana-mods.sh /path/to/manifest.json arkana-mods.nix` after a modpack version bump.
+- `arkana-mods-extras.nix` — three lists:
+  - `replacements` — newer file-IDs swapped for entries in `arkana-mods.nix` whose Arkana version is incompatible with our bumped floor. Set `alwaysInclude = true` for replacements that are part of the floor itself (Create 6.0.10 is the only one today). Replacements without `alwaysInclude` only apply when their `origProjectID`'s group is enabled.
+  - `skipped` — discontinued mods with no live file on CurseForge. Always dropped server-side; client zip strips manifest entries so the launcher doesn't error on import.
+  - `disabled` — mods that boot-fail under our bumped floor. Always dropped, even when their group is enabled. Includes a `reason` and `phase` field for the next person debugging.
+- `arkana-groups.nix` — auto-classified by `group-classifier.py` from arkana-mods.nix filenames. Pure regex pattern matching; hand-tweak the classifier rules when bisect surfaces a misclassified mod (e.g. `gtbcs_spell_lib` originally landed in `core-libs` but hard-deps `irons_spellbooks` so it moved to `irons-spells`).
+- `overlays.nix` — Aeronautics + Sable + companions + library mods we add on top of Arkana. Each entry can carry `requiresGroup = "<name>"` so libraries (e.g. AeroBlender needs the `world` group's aether + terrablender) only ship when their dependents would actually load.
+
+## The bisect loop
+
+```bash
+# 1. Boot the floor (no Arkana groups). Should always pass.
+./pkgs/create-arkana-aeronautics-server/bisect.sh
+
+# 2. Pre-flight dep check on the floor + every Arkana group together.
+nix build --impure --expr '
+  let f = builtins.getFlake "."; sys = "aarch64-linux";
+      pkgs = import f.inputs.nixpkgs { system = sys; config.allowUnfree = true; overlays = builtins.attrValues f.outputs.overlays; };
+  in pkgs.create-arkana-aeronautics-server.override {
+       enabledArkanaGroups = [ "core-libs" "apothic" "irons-spells" ... ];
+     }'
+# Build is gated by an installPhase dep-tree check — fails before docker
+# layering if any required dep is missing or out-of-version-range. Surfaces
+# blockers in seconds, not multi-minute boot cycles.
+nix run .#dep-tree -- /nix/store/<server-tree-path>
+
+# 3. Boot whatever passes (1) above.
+./pkgs/create-arkana-aeronautics-server/bisect.sh core-libs apothic ...
+# Watches docker logs for "Done (Xs)" or any FATAL/Failed-to-load line and
+# dumps the latest crash report on failure.
+
+# 4. For each FATAL surfaced: add the offender + its hard-dependents to
+#    `disabled = [ ... ]` in arkana-mods-extras.nix, with a reason + phase.
+#    Use `dep-tree --dependents <modId>` to find what cascades.
+#    Re-run (3). Repeat.
+```
+
+Optimizations baked in: bisect.sh keeps `/data/libraries` between rounds (`FRESH=1` to wipe), server.properties pins `level-type=minecraft\:flat` (~10s saved per round on spawn-prepare), installPhase fails fast on dep-graph regressions.
+
+## Mod-version bumping (after the pack boots clean)
+
+`pkgs/minecraft-modpack-tools/find-mod-bumps.py` walks the dep graph leaf-first, queries cfwidget + Modrinth for each mod's newest 1.21.1/NeoForge build, downloads candidates, and verifies forward + reverse `versionRange` compat. Emits ready-to-paste `replacements` blocks for `arkana-mods-extras.nix` with `$(nix hash file ...)` placeholders.
+
+Run against the **built** server tree's `mods/`:
+
+```bash
+# Export mods from the OCI image
+docker run --rm -v /tmp/mods:/out --entrypoint /bin/sh \
+  ghcr.io/<user>/create-arkana-aeronautics-server:<tag> \
+  -c 'mkdir -p /out/mods && cp -L /opt/server/mods/*.jar /out/mods/'
+
+python3 pkgs/minecraft-modpack-tools/find-mod-bumps.py /tmp
+```
+
+**Caveats — the tool's check is permissive:**
+- Forward/reverse uses declared `mods.toml` `versionRange` only. Mods commonly declare open ranges (`[0.10,)`); these admit any newer lib on paper but the dependent's bytecode may reference classes the new lib removed → runtime `NoClassDefFoundError` / `MixinTransformerError`. **Always boot-test after applying bumps.**
+- Tool prints `no compatible newer version found` for a dependent when its newer published versions declare a lib `versionRange` excluding the current lib version. That's the **lockstep bump signal** — bump lib + dependent together. Confirmed safe bundles: sophisticated-family (core + storage + backpacks + 2 create-integrations), familiarslib 1.7 + alshanex_familiars v4, irons_spellbooks family (spellbooks + jewelry + gtbcs_spell_lib + aces_spell_utils).
+- Known-bad ABI bumps (will drop mods): `relics 0.12.4` removes `IRelicItem`/`IRenderableCurio`/`ExperienceAddEvent` used by arcane_abilities, reliquified_lenders_cataclysm, reliquified_ars_nouveau; `azurelib 3.1.8` moves `AzureLib` class used by crystal_chronicles, cataclysm_spellbooks; `twilightforest 4.8` MixinTransformerError; `moonlight 3.0.7` major.
+- **Ignore NeoForge in-game `OUTDATED` reports.** NF string-compares `version=` against Modrinth's `forge_updates.json` `promos` which auto-publishes versions with `+mod` / `+mc1.21.1` metadata suffixes. Use `find-mod-bumps` for ground truth.
+- `lionfishapi 2.7-fix-fix` drops `IAnimatedEntity` — `arkana-mods-extras.nix` pins 2.6. Comment in extras explains; don't bump.
+- cfwidget's fileID sort isn't strictly version-sorted; watch for downgrades (`jeresources 1.6.0.17 → .12`).
+
+**Shipping a bump round:**
+1. Apply bumps to `arkana-mods-extras.nix`. Dedupe by `projectID` (one entry per mod); preserve original arkana `origFileID` when overwriting an earlier replacement.
+2. New mods (not in `arkana-mods.nix`) go into `overlays.nix` via the `curseforge` or `modrinth` helper.
+3. `nix build .#minecraft-arkana-aeronautics-image` → `docker load < <path>` → fresh container, watch for `Done (Xs)` and `failed to load correctly`.
+4. If broken: pull crash report from logs, identify failing mod, revert that bump, rebuild. Bisect by removing bumps in groups if multiple fail.
+5. Commit + annotated tag `arkana-aeronautics-v<modpack-version>-<n>`. GHA workflow only fires on tag push.
+6. Update gitops `clusters/aws-k3s/flux-system/minecraft/deployment.yaml` image tag separately to roll the deployed server.
+
+## Known issue: OpenLoader datapack path
+
+`entrypoint.sh` symlinks `/data/openloader/data/` → `/opt/server/openloader/data/` for the OpenLoader mod to pick up shipped datapacks (move-spawners, rare-pixie-villages, ensure-vanilla-tags). **OpenLoader 21.1.5 actually scans `/data/config/openloader/packs/` instead** — the old path is ignored. Server-side datapacks silently don't load. Confirmed via `docker logs` showing `[Open Loader/]: Located 0 packs.`. Fix pending: symlink to the new path or write `/data/config/openloader/options.json` with `additional_locations: ["openloader/data"]` from the entrypoint.
+
+## Crash-pattern triage
+
+| Signature | Phase | Likely fix |
+|---|---|---|
+| `Mod X requires Y N.N or above` | dep-resolution | bump in `replacements`, or move Y into an enabled group |
+| `Attempted to load class net/minecraft/client/...` | class-load | mod is client-only; add to `clientOnlyProjectIDs` in `default.nix` |
+| `failed injection check, (0/N) succeeded` mixin | mod-construction | mod's mixin targets removed/renamed API on the bumped Create / NeoForge — bump the mod or `disabled` it |
+| `Trying to access unbound value: ResourceKey[...]` | registry-init | `DeferredHolder` resolved before its registry runs; usually a mod's mixin firing during another mod's RegisterEvent. Hard to fix without bumping the mixin source — usually `disabled` |
+| `Cannot get config value before config is loaded` | common-setup | mod calls config.get from FMLCommonSetupEvent; NeoForge 21.1.x lifecycle incompatibility — `disabled` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,102 +184,13 @@ Key configurations defined in the flake:
 
 ### Minecraft modpack server packaging
 
-Two patterns ship Minecraft modpacks as Nix-built OCI images:
-
-- `pkgs/create-sky-colonies-server` — vanilla pattern. The publisher releases a "Server Pack" zip; we `fetchurl` it and overlay perf mods + JVM args + entrypoint. Used for any modpack whose publisher ships a pre-installed server tree.
-- `pkgs/create-arkana-aeronautics-server` — manifest-driven pattern with bisection. Modpack ships only a CurseForge "manifest pack" (manifest.json + overrides/, no jars), so we resolve every mod via cfwidget+mediafilez into `arkana-mods.nix`, run the NeoForge installer at first boot to populate `/data/libraries`, and bisect mod groups to find what coexists.
-
-The bisection workflow is the part worth knowing. `pkgs/minecraft-modpack-tools` ships generic helpers (`dep-tree` is the only one currently); `pkgs/create-arkana-aeronautics-server` keeps the modpack-specific pieces (`group-classifier.py`, `bisect.sh`, `generate-arkana-mods.sh`).
-
-#### When to bisect
-
-Whenever a modpack's overlay (extra mods we add on top) requires a Create / NeoForge / library version newer than what the base modpack ships. Bumping a single core lib often cascades into mod-construction or registry-init NPEs across 5-15 unrelated mods that were tuned to the older API. Bisecting identifies which Arkana mods stay compatible with the bumped floor — keep those, disable the rest.
-
-#### The four files that drive composition
-
-- `arkana-mods.nix` — auto-generated from the modpack's manifest.json. **Don't hand-edit.** Regenerate with `generate-arkana-mods.sh /path/to/manifest.json arkana-mods.nix` after a modpack version bump.
-- `arkana-mods-extras.nix` — three lists:
-  - `replacements` — newer file-IDs swapped for entries in `arkana-mods.nix` whose Arkana version is incompatible with our bumped floor. Set `alwaysInclude = true` for replacements that are part of the floor itself (Create 6.0.10 is the only one today). Replacements without `alwaysInclude` only apply when their `origProjectID`'s group is enabled.
-  - `skipped` — discontinued mods with no live file on CurseForge. Always dropped server-side; client zip strips manifest entries so the launcher doesn't error on import.
-  - `disabled` — mods that boot-fail under our bumped floor. Always dropped, even when their group is enabled. Includes a `reason` and `phase` field for the next person debugging.
-- `arkana-groups.nix` — auto-classified by `group-classifier.py` from arkana-mods.nix filenames. Pure regex pattern matching; hand-tweak the classifier rules when bisect surfaces a misclassified mod (e.g. `gtbcs_spell_lib` originally landed in `core-libs` but hard-deps `irons_spellbooks` so it moved to `irons-spells`).
-- `overlays.nix` — Aeronautics + Sable + companions + library mods we add on top of Arkana. Each entry can carry `requiresGroup = "<name>"` so libraries (e.g. AeroBlender needs the `world` group's aether + terrablender) only ship when their dependents would actually load.
-
-#### The bisect loop
-
-```bash
-# 1. Boot the floor (no Arkana groups). Should always pass.
-./pkgs/create-arkana-aeronautics-server/bisect.sh
-
-# 2. Pre-flight dep check on the floor + every Arkana group together.
-nix build --impure --expr '
-  let f = builtins.getFlake "."; sys = "aarch64-linux";
-      pkgs = import f.inputs.nixpkgs { system = sys; config.allowUnfree = true; overlays = builtins.attrValues f.outputs.overlays; };
-  in pkgs.create-arkana-aeronautics-server.override {
-       enabledArkanaGroups = [ "core-libs" "apothic" "irons-spells" ... ];
-     }'
-# Build is gated by an installPhase dep-tree check — fails before docker
-# layering if any required dep is missing or out-of-version-range. Surfaces
-# blockers in seconds, not multi-minute boot cycles.
-nix run .#dep-tree -- /nix/store/<server-tree-path>
-
-# 3. Boot whatever passes (1) above.
-./pkgs/create-arkana-aeronautics-server/bisect.sh core-libs apothic ...
-# Watches docker logs for "Done (Xs)" or any FATAL/Failed-to-load line and
-# dumps the latest crash report on failure.
-
-# 4. For each FATAL surfaced: add the offender + its hard-dependents to
-#    `disabled = [ ... ]` in arkana-mods-extras.nix, with a reason + phase.
-#    Use `dep-tree --dependents <modId>` to find what cascades.
-#    Re-run (3). Repeat.
-```
-
-Optimizations baked in: bisect.sh keeps `/data/libraries` between rounds (`FRESH=1` to wipe), server.properties pins `level-type=minecraft\:flat` (~10s saved per round on spawn-prepare), installPhase fails fast on dep-graph regressions.
-
-#### Mod-version bumping (after the pack boots clean)
-
-`pkgs/minecraft-modpack-tools/find-mod-bumps.py` walks the dep graph leaf-first, queries cfwidget + Modrinth for each mod's newest 1.21.1/NeoForge build, downloads candidates, and verifies forward + reverse `versionRange` compat. Emits ready-to-paste `replacements` blocks for `arkana-mods-extras.nix` with `$(nix hash file ...)` placeholders.
-
-Run against the **built** server tree's `mods/`:
-
-```bash
-# Export mods from the OCI image
-docker run --rm -v /tmp/mods:/out --entrypoint /bin/sh \
-  ghcr.io/<user>/create-arkana-aeronautics-server:<tag> \
-  -c 'mkdir -p /out/mods && cp -L /opt/server/mods/*.jar /out/mods/'
-
-python3 pkgs/minecraft-modpack-tools/find-mod-bumps.py /tmp
-```
-
-**Caveats — the tool's check is permissive:**
-- Forward/reverse uses declared `mods.toml` `versionRange` only. Mods commonly declare open ranges (`[0.10,)`); these admit any newer lib on paper but the dependent's bytecode may reference classes the new lib removed → runtime `NoClassDefFoundError` / `MixinTransformerError`. **Always boot-test after applying bumps.**
-- Tool prints `no compatible newer version found` for a dependent when its newer published versions declare a lib `versionRange` excluding the current lib version. That's the **lockstep bump signal** — bump lib + dependent together. Confirmed safe bundles: sophisticated-family (core + storage + backpacks + 2 create-integrations), familiarslib 1.7 + alshanex_familiars v4, irons_spellbooks family (spellbooks + jewelry + gtbcs_spell_lib + aces_spell_utils).
-- Known-bad ABI bumps (will drop mods): `relics 0.12.4` removes `IRelicItem`/`IRenderableCurio`/`ExperienceAddEvent` used by arcane_abilities, reliquified_lenders_cataclysm, reliquified_ars_nouveau; `azurelib 3.1.8` moves `AzureLib` class used by crystal_chronicles, cataclysm_spellbooks; `twilightforest 4.8` MixinTransformerError; `moonlight 3.0.7` major.
-- **Ignore NeoForge in-game `OUTDATED` reports.** NF string-compares `version=` against Modrinth's `forge_updates.json` `promos` which auto-publishes versions with `+mod` / `+mc1.21.1` metadata suffixes. Use `find-mod-bumps` for ground truth.
-- `lionfishapi 2.7-fix-fix` drops `IAnimatedEntity` — `arkana-mods-extras.nix` pins 2.6. Comment in extras explains; don't bump.
-- cfwidget's fileID sort isn't strictly version-sorted; watch for downgrades (`jeresources 1.6.0.17 → .12`).
-
-**Shipping a bump round:**
-1. Apply bumps to `arkana-mods-extras.nix`. Dedupe by `projectID` (one entry per mod); preserve original arkana `origFileID` when overwriting an earlier replacement.
-2. New mods (not in `arkana-mods.nix`) go into `overlays.nix` via the `curseforge` or `modrinth` helper.
-3. `nix build .#minecraft-arkana-aeronautics-image` → `docker load < <path>` → fresh container, watch for `Done (Xs)` and `failed to load correctly`.
-4. If broken: pull crash report from logs, identify failing mod, revert that bump, rebuild. Bisect by removing bumps in groups if multiple fail.
-5. Commit + annotated tag `arkana-aeronautics-v<modpack-version>-<n>`. GHA workflow only fires on tag push.
-6. Update gitops `clusters/aws-k3s/flux-system/minecraft/deployment.yaml` image tag separately to roll the deployed server.
-
-#### Known issue: OpenLoader datapack path
-
-`entrypoint.sh` symlinks `/data/openloader/data/` → `/opt/server/openloader/data/` for the OpenLoader mod to pick up shipped datapacks (move-spawners, rare-pixie-villages, ensure-vanilla-tags). **OpenLoader 21.1.5 actually scans `/data/config/openloader/packs/` instead** — the old path is ignored. Server-side datapacks silently don't load. Confirmed via `docker logs` showing `[Open Loader/]: Located 0 packs.`. Fix pending: symlink to the new path or write `/data/config/openloader/options.json` with `additional_locations: ["openloader/data"]` from the entrypoint.
-
-#### Crash-pattern triage
-
-| Signature | Phase | Likely fix |
-|---|---|---|
-| `Mod X requires Y N.N or above` | dep-resolution | bump in `replacements`, or move Y into an enabled group |
-| `Attempted to load class net/minecraft/client/...` | class-load | mod is client-only; add to `clientOnlyProjectIDs` in `default.nix` |
-| `failed injection check, (0/N) succeeded` mixin | mod-construction | mod's mixin targets removed/renamed API on the bumped Create / NeoForge — bump the mod or `disabled` it |
-| `Trying to access unbound value: ResourceKey[...]` | registry-init | `DeferredHolder` resolved before its registry runs; usually a mod's mixin firing during another mod's RegisterEvent. Hard to fix without bumping the mixin source — usually `disabled` |
-| `Cannot get config value before config is loaded` | common-setup | mod calls config.get from FMLCommonSetupEvent; NeoForge 21.1.x lifecycle incompatibility — `disabled` |
+Server-side Minecraft modpack packaging — the `create-sky-colonies-server`
+(vanilla) and `create-arkana-aeronautics-server` (manifest + bisection)
+patterns, the bisect loop, mod-version bumping (`find-mod-bumps`), the
+composition files, and crash-pattern triage — lives in the
+**`minecraft-modpack-packaging`** skill
+(`.claude/skills/minecraft-modpack-packaging/SKILL.md`), loaded on demand when
+working on `pkgs/create-*-server` / `pkgs/minecraft-modpack-tools`.
 
 ### Pending: niks3 cache push on desktops/laptops
 

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -57,13 +57,29 @@ let
 
   # Merge skill directories — cavekit is installed as a plugin (plugin-dir) so it's excluded here.
   # ./skills holds locally-authored global skills (process-todo, ...).
+  #
+  # Curated subset of anthropics/skills rather than the whole repo: every skill's
+  # name+description loads into every agent/subagent, so the unused ones
+  # (algorithmic-art, brand-guidelines, canvas-design, theme-factory) are dropped
+  # to trim the subagent baseline.
+  anthropicSkillNames = [
+    # Document / office
+    "docx" "pdf" "pptx" "xlsx"
+    # Dev / web
+    "frontend-design" "web-artifacts-builder" "webapp-testing" "mcp-builder"
+    # Authoring / meta
+    "doc-coauthoring" "internal-comms" "skill-creator"
+    # Misc kept
+    "slack-gif-creator"
+  ];
   allSkills = pkgs.symlinkJoin {
     name = "claude-code-skills";
-    paths = [
-      "${anthropicSkills}/skills"
-      "${cavemanPkg}/skills"
-      ./skills
-    ];
+    paths =
+      (map (n: "${anthropicSkills}/skills/${n}") anthropicSkillNames)
+      ++ [
+        "${cavemanPkg}/skills"
+        ./skills
+      ];
   };
 
   lspmuxPkg = inputs.ali-neovim.packages.${pkgs.stdenv.hostPlatform.system}.lspmux;

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -109,6 +109,15 @@ let
     docker     = { ".dockerfile" = "dockerfile"; };
   };
 
+  # Datadog-scoped Claude: layers the pup-claude plugin (Datadog `pup` CLI + 49
+  # agents + skills) onto the default wrapped `claude` only when invoked, keeping
+  # pup out of the default session/subagent baseline. Resolves `claude` from the
+  # ambient PATH (the home-manager-wrapped binary) so its own --plugin-dir /
+  # --mcp-config wrapping is preserved; this just appends another --plugin-dir.
+  claudeDd = pkgs.writeShellScriptBin "claude-dd" ''
+    exec claude --plugin-dir ${pkgs.pup-claude} "$@"
+  '';
+
   # Map friendly name → binary path from neovim flake's exports.
   # Prefers faster alternatives (pyright, vtsls, tfls) where available.
   serverBinaries = {
@@ -131,7 +140,7 @@ in
   # token-savior stats viewers on PATH. Not the whole pkgs.token-savior — that
   # would also drop the broken token-savior-bench, the server bin, and the
   # stats-less `ts` onto PATH.
-  home.packages = [ tsStatsDashboard tsStatsCli ];
+  home.packages = [ tsStatsDashboard tsStatsCli claudeDd ];
 
   programs.claude-code = {
     enable = true;
@@ -450,8 +459,11 @@ in
     skills = "${allSkills}";
 
     # cavekit as a plugin so Claude Code loads it with the "ck:" namespace
-    # (giving /ck:spec, /ck:build, /ck:check)
-    plugins = [ cavekitPkg pkgs.pup-claude pkgs.superpowers ];
+    # (giving /ck:spec, /ck:build, /ck:check).
+    # pup-claude is intentionally NOT global — it ships 49 agents + ~14 skills
+    # that would load into every session/subagent. It's layered in on demand via
+    # the `claude-dd` wrapper (see let block) only for Datadog work.
+    plugins = [ cavekitPkg pkgs.superpowers ];
 
     # Listed explicitly (not agentsDir) so the shared gitStrategy mandate can
     # be appended to the git-touching agents.

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -109,6 +109,67 @@ let
     docker     = { ".dockerfile" = "dockerfile"; };
   };
 
+  # ---- MCP gateway (mcp-gateway) ---------------------------------------------
+  # A single always-on aggregator MCP server that hosts the heavy / situational
+  # downstream servers (github, k8s, terraform, obscura, context7). Those
+  # downstreams connect to the GATEWAY, not to Claude Code — so their tool names
+  # AND their verbose `instructions` blocks never enter Claude Code's per-session
+  # context (the dominant subagent-baseline cost). The model reaches them lazily
+  # through the gateway_* meta-tools (gateway_search_tools / gateway_invoke).
+  #
+  # We do NOT route nixos / cavemem / token-savior through the gateway: nixos is
+  # used constantly in this repo, and token-savior must stay first-class so the
+  # Pre/PostToolUse hooks' mcp__.* matchers keep firing.
+  #
+  # mcp-gateway's per-backend `command` is a single shlex-split string with NO
+  # `args` list and NO shell — so github + obscura (which need launch-time setup:
+  # a gh-keyring token; an obscura storage dir + UK-locale env) are each wrapped
+  # in their own store-path launcher script, referenced as an absolute command.
+  githubMcpLauncher = pkgs.writeShellScript "github-mcp-launcher" ''
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(${pkgs.gh}/bin/gh auth token)"
+    exec ${pkgs.master.github-mcp-server}/bin/github-mcp-server stdio
+  '';
+
+  obscuraMcpLauncher = pkgs.writeShellScript "obscura-mcp-launcher" ''
+    dir="''${XDG_STATE_HOME:-$HOME/.local/state}/obscura"
+    mkdir -p "$dir"
+    exec env OBSCURA_TIMEZONE=Europe/London OBSCURA_GEOLOCATION=51.5074,-0.1278 \
+      ${pkgs.obscura}/bin/obscura --storage-dir "$dir" \
+      mcp --stealth --allow-private-network
+  '';
+
+  # YAML config for the gateway. `command` strings are shlex-split (spaces =
+  # arg separators), so absolute store paths + plain trailing args are fine;
+  # anything needing env/setup goes through a launcher script above.
+  mcpGatewayConfig = pkgs.writeText "mcp-gateway.yaml" ''
+    meta_mcp:
+      enabled: true
+      # warm_start is REQUIRED for discovery: without it backends stay stopped
+      # with tools_count=0 and gateway_search_tools returns nothing. Warm-start
+      # spawns each backend once at session start and caches its tool list, so
+      # the model can find downstream tools via gateway_search_tools — while the
+      # client still sees only the ~15 gateway_* meta-tools (the token win). This
+      # is no worse than the old setup, where each of these ran as a direct
+      # per-session MCP server anyway (just with all their tool names in context).
+      warm_start: ["github", "k8s", "terraform", "obscura", "context7"]
+    backends:
+      github:
+        description: "GitHub API: issues, pull requests, code search, releases, commits"
+        command: "${githubMcpLauncher}"
+      k8s:
+        description: "Kubernetes: contexts, namespaces, nodes, resources, pod logs and exec"
+        command: "${pkgs.master.mcp-k8s-go}/bin/mcp-k8s-go"
+      terraform:
+        description: "Terraform registry: providers, modules, policies and docs"
+        command: "${pkgs.master.terraform-mcp-server}/bin/terraform-mcp-server stdio"
+      obscura:
+        description: "Headless stealth browser for web scraping, fetches and form automation"
+        command: "${obscuraMcpLauncher}"
+      context7:
+        description: "Up-to-date library / framework / SDK documentation lookup"
+        command: "${pkgs.master.context7-mcp}/bin/context7-mcp"
+  '';
+
   # Datadog-scoped Claude: layers the pup-claude plugin (Datadog `pup` CLI + 49
   # agents + skills) onto the default wrapped `claude` only when invoked, keeping
   # pup out of the default session/subagent baseline. Resolves `claude` from the
@@ -189,14 +250,17 @@ in
           "Write(*)"
           "WebFetch(*)"
           "WebSearch(*)"
-          "mcp__obscura__*"
-          "mcp__context7__*"
-          "mcp__github__*"
           "mcp__nixos__*"
-          "mcp__k8s__*"
-"mcp__terraform__*"
           "mcp__cavemem__*"
           "mcp__token-savior__*"
+          # MCP gateway: auto-allow only the read-only discovery meta-tools.
+          # gateway_invoke is deliberately NOT allowed so that actual downstream
+          # calls (incl. k8s / terraform mutations, github writes) prompt — the
+          # Bash safety hook never covered MCP tools, and routing 5 servers
+          # through one gateway would otherwise collapse their per-server gating.
+          "mcp__mcp-gateway__gateway_list_servers"
+          "mcp__mcp-gateway__gateway_list_tools"
+          "mcp__mcp-gateway__gateway_search_tools"
           "Bash(git:*)"
           "Bash(GIT_PAGER=cat git:*)"
           "Bash(GIT_DIFF_OPTS= git:*)"
@@ -479,57 +543,21 @@ in
     context = builtins.concatStringsSep "\n" [ gitStrategy modelRouting workStyle ];
 
     mcpServers = {
-      # Headless stealth browser for AI agents / web scraping.
-      #   --stealth: BoringSSL Chrome TLS impersonation + JS fingerprint spoof.
-      #   --allow-private-network: permit loopback/RFC1918/link-local fetches
-      #     (off by default as SSRF guard) so local dev servers are reachable.
-      #   --storage-dir: persist cookies + localStorage across sessions, so a
-      #     clearance cookie (cf_clearance / Akamai _abck) solved once in a
-      #     real browser on this residential IP can be reused.
-      #   OBSCURA_TIMEZONE/GEOLOCATION: align the spoofed locale with our UK IP
-      #     (mismatched timezone vs IP geo is a bot-detection signal).
-      # Wrapped in bash so $HOME expands at runtime (no `config` in scope here)
-      # and the env vars apply to the long-lived MCP process.
-      obscura = {
-        command = "bash";
-        args = [
-          "-c"
-          ''
-            dir="''${XDG_STATE_HOME:-$HOME/.local/state}/obscura"
-            mkdir -p "$dir"
-            exec env OBSCURA_TIMEZONE=Europe/London OBSCURA_GEOLOCATION=51.5074,-0.1278 \
-              ${pkgs.obscura}/bin/obscura --storage-dir "$dir" \
-              mcp --stealth --allow-private-network
-          ''
-        ];
+      # Aggregator gateway hosting the heavy / situational servers (github, k8s,
+      # terraform, obscura, context7) as lazy downstreams — see mcpGatewayConfig
+      # in the let block. Only the gateway_* meta-tools enter Claude Code's
+      # context; downstream tool names + instruction blocks do not. The model
+      # discovers + calls downstream tools via gateway_search_tools /
+      # gateway_invoke. `serve --stdio` makes the gateway itself a stdio server.
+      mcp-gateway = {
+        command = "${pkgs.master.mcp-gateway}/bin/mcp-gateway";
+        args = [ "serve" "--stdio" "--config" "${mcpGatewayConfig}" ];
       };
 
-      # Up-to-date library documentation
-      context7 = {
-        command = "${pkgs.master.context7-mcp}/bin/context7-mcp";
-      };
-
-      # GitHub API integration (issues, PRs, code search)
-      # Wraps with gh auth token to pull the token from gh's keyring
-      github = {
-        command = "bash";
-        args = [ "-c" "GITHUB_PERSONAL_ACCESS_TOKEN=$(${pkgs.gh}/bin/gh auth token) exec ${pkgs.master.github-mcp-server}/bin/github-mcp-server stdio" ];
-      };
-
-      # NixOS/Home Manager options and package search
+      # NixOS/Home Manager options and package search — kept direct (first-class;
+      # used constantly in this repo).
       nixos = {
         command = "${pkgs.master.mcp-nixos}/bin/mcp-nixos";
-      };
-
-      # Kubernetes cluster interaction
-      k8s = {
-        command = "${pkgs.master.mcp-k8s-go}/bin/mcp-k8s-go";
-      };
-
-      # Terraform registry and provider documentation
-      terraform = {
-        command = "${pkgs.master.terraform-mcp-server}/bin/terraform-mcp-server";
-        args = [ "stdio" ];
       };
 
       # Cavemem: persistent cross-session memory (search, timeline, get_observations)


### PR DESCRIPTION
## Why

Every Claude Code session — and every subagent — started at a large fixed
context baseline (~19k tokens for subagents). Tool *schemas* are already
deferred (ToolSearch), so the cost is the always-loaded surface: MCP tool
**names** + each server's verbose **instructions block**, the full skills list,
and large CLAUDE.md sections. This trims that surface.

## What

- **MCP aggregator gateway** (`pkgs.master.mcp-gateway`, v2.19.0): github, k8s,
  terraform, obscura and context7 move behind one always-on stdio gateway as
  warm-started downstreams. Claude Code now sees only the ~15 `gateway_*`
  meta-tools instead of ~100 downstream tool names + 4-5 instruction blocks; the
  model discovers/calls downstream tools via `gateway_search_tools` /
  `gateway_invoke`. `nixos`, `cavemem`, `token-savior` stay first-class
  (token-savior is coupled to the Pre/PostToolUse `mcp__.*` hooks).
- **Skills prune**: restrict the anthropics/skills bundle to a keep-list,
  dropping algorithmic-art, brand-guidelines, canvas-design, theme-factory.
- **pup-claude scoped**: out of the global plugins list; layered on demand via a
  new `claude-dd` wrapper (`--plugin-dir`) only for Datadog work.
- **Minecraft packaging docs** → `.claude/skills/minecraft-modpack-packaging/`
  project skill (loads on demand), with a one-line pointer left in CLAUDE.md.

## Security note

The gateway routes 5 servers behind one tool surface. Only the read-only
discovery meta-tools (`gateway_list_servers/list_tools/search_tools`) are
auto-allowed; `gateway_invoke` is intentionally **not** allow-listed, so
downstream k8s/terraform mutations and github writes still prompt. (The Bash
safety hook never covered MCP tools, and stdio mode bypasses the gateway's own
destructive-confirmation.)

## Verification

- `nix-instantiate --parse` OK; all packages resolve (incl. obscura 0.1.8).
- The rendered gateway config builds; **live stdio handshake** confirmed: init
  OK, 15 meta-tools exposed, and `warm_start` populates discovery (k8s=9,
  terraform=9, context7=2 tools cached).
- `meta_mcp.warm_start` is **required** — without it backends stay stopped and
  `gateway_search_tools` returns nothing.

Full home-manager activation (`just switch`) still needs to be run on a host;
after switching, `/context` should show reduced MCP + skills lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)