### PR TITLE
harden(hetzner): enable Cilium host firewall [B37]

### DIFF
--- a/flake-modules/hetzner-cilium-bootstrap.yaml
+++ b/flake-modules/hetzner-cilium-bootstrap.yaml
@@ -23,6 +23,15 @@ spec:
     k8sServiceHost: "10.0.1.10"
     k8sServicePort: "6443"
 
+    # Host firewall [B37]: lets a CiliumClusterwideNetworkPolicy with nodeSelector
+    # police the NODE's own (host-netns) traffic, not just pods — defence in depth
+    # beyond the hcloud Cloud Firewall. The allow policy is GitOps
+    # (network-policies/cp-host-firewall). Validated live in audit mode + Hubble
+    # (zero would-be-drops) before enforcing. NB: with no host policy the host is
+    # default-ALLOW (fail-open), so enabling this alone never locks the node out.
+    hostFirewall:
+      enabled: true
+
     # IPAM delegated to k3s (--cluster-cidr); avoids a second allocator.
     ipam:
       mode: kubernetes


### PR DESCRIPTION
Enable `hostFirewall` in the cilium bootstrap values so a `CiliumClusterwideNetworkPolicy` (GitOps: home-cluster `network-policies/cp-host-firewall`) can police the **node's own host-netns traffic**, not just pods — defence in depth beyond the hcloud Cloud Firewall.

Validated live before baking: enabled host-fw, host endpoint → audit mode, applied the allow policy, watched **Hubble** `policy-verdict --verdict AUDIT` = **zero** would-be-drops across diverse traffic (fresh SSH, k3s API, kubelet, envoy 443, tailscale, metadata, S3), then enforced behind a dead-man's-switch → SSH/API/ingress all healthy.

With no host policy the host is default-**allow** (fail-open), so enabling this alone cannot lock a node out; the GitOps policy (home-cluster #1211) provides the allow rules.

VM test `hetzner-karpenter-node` + `nix eval` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)