### PR TITLE
fix(claude-code): restore /remote-control + fix CLI subcommands

### DIFF
--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -208,15 +208,20 @@ in
     package = pkgs.master.claude-code;
 
     settings = {
-      # Opt out of telemetry/autoupdate/error-reporting WITHOUT the umbrella
-      # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC var: that umbrella also blocks
-      # the Remote Control backplane (outbound HTTPS register+poll to the
-      # Anthropic API), which silently removes /remote-control from the menu.
-      # Granular vars below disable the same telemetry/update/report traffic
-      # but leave remote-control working. DISABLE_TELEMETRY also suppresses the
-      # superpowers brainstorm primeradiant.com logo beacon.
+      # Opt out of autoupdate/error-reporting/bug-command. We deliberately do
+      # NOT set DISABLE_TELEMETRY (nor the umbrella
+      # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC): DISABLE_TELEMETRY also
+      # disables Claude Code's feature-flag (GrowthBook) evaluation, which
+      # Remote Control requires — setting it silently removes /remote-control
+      # from the menu ("Remote Control requires feature-flag evaluation, which
+      # is disabled because DISABLE_TELEMETRY is set"). Leaving it unset only
+      # re-enables the feature-flag config fetch; OTel usage export stays off
+      # (opt-in via CLAUDE_CODE_ENABLE_TELEMETRY, unset). The superpowers
+      # brainstorm primeradiant.com logo beacon — the original reason for
+      # DISABLE_TELEMETRY — is suppressed independently via its own dedicated
+      # SUPERPOWERS_DISABLE_TELEMETRY switch below.
       env = {
-        DISABLE_TELEMETRY = "1";
+        SUPERPOWERS_DISABLE_TELEMETRY = "1";
         DISABLE_AUTOUPDATER = "1";
         DISABLE_ERROR_REPORTING = "1";
         DISABLE_BUG_COMMAND = "1";

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -179,6 +179,61 @@ let
     exec claude --plugin-dir ${pkgs.pup-claude} "$@"
   '';
 
+  # Subcommand-aware dispatcher nested INSIDE programs.claude-code.package.
+  #
+  # The home-manager claude-code module delivers our mcpServers + lspServers
+  # (and cavekit/superpowers) by wrapping the binary with `--plugin-dir <…>`
+  # flags injected into EVERY invocation. But Claude Code's subcommands
+  # (`remote-control`, `mcp`, `setup-token`, …) reject `--plugin-dir` and die
+  # with `Error: Unknown argument: <plugindir>`. The module's `finalPackage`
+  # wrapper is readOnly/internal (not overridable) and structural (it carries
+  # the MCP/LSP config), so we can't drop it.
+  #
+  # Instead we hand the module a `package` whose own `bin/claude` is this
+  # dispatcher around the real binary (`bin/.claude-real`). The module then
+  # renames our dispatcher to `.claude-wrapped` and wraps THAT with its
+  # `--plugin-dir` flags. Call chain: module-wrapper → dispatcher → real claude.
+  # The dispatcher peels the module-injected flags and forwards them only for
+  # the bare REPL / prompt invocations, stripping them when a subcommand follows
+  # so subcommands run clean. `@REAL@` is substituted with the absolute store
+  # path of `.claude-real` at build time (below).
+  claudeDispatcher = pkgs.writeShellScript "claude-dispatcher" ''
+    inject=()
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        # `--flag=value` form: single token.
+        --plugin-dir=*|--plugin-dir-no-mcp=*|--mcp-config=*) inject+=("$1"); shift ;;
+        # `--flag value` form: consume the value too, but guard against a
+        # trailing flag with no value (else `shift 2` errors / loops forever).
+        --plugin-dir|--plugin-dir-no-mcp|--mcp-config)
+          if [ $# -ge 2 ]; then inject+=("$1" "$2"); shift 2; else inject+=("$1"); shift; fi ;;
+        *) break ;;
+      esac
+    done
+    case "''${1:-}" in
+      remote-control|rc|mcp|config|setup-token|update|doctor|plugin|marketplace|login|logout|auth|agents|serve|install|migrate-installer|setup)
+        # Subcommand: drop the injected --plugin-dir/--mcp-config flags.
+        exec -a "$0" @REAL@ "$@" ;;
+      *)
+        # REPL or prompt arg: keep the plugins/MCP config.
+        exec -a "$0" @REAL@ "''${inject[@]}" "$@" ;;
+    esac
+  '';
+
+  # claude-code with bin/claude replaced by the dispatcher; the upstream
+  # entrypoint is preserved as bin/.claude-real.
+  claudeWrapped = pkgs.symlinkJoin {
+    name = "claude-code";
+    paths = [ pkgs.master.claude-code ];
+    postBuild = ''
+      mv $out/bin/claude $out/bin/.claude-real
+      install -m755 ${claudeDispatcher} $out/bin/claude
+      substituteInPlace $out/bin/claude --replace '@REAL@' "$out/bin/.claude-real"
+      chmod 555 $out/bin/claude
+    '';
+    inherit (pkgs.master.claude-code) meta;
+  };
+
   # Map friendly name → binary path from neovim flake's exports.
   # Prefers faster alternatives (pyright, vtsls, tfls) where available.
   serverBinaries = {
@@ -205,7 +260,7 @@ in
 
   programs.claude-code = {
     enable = true;
-    package = pkgs.master.claude-code;
+    package = claudeWrapped;
 
     settings = {
       # Opt out of autoupdate/error-reporting/bug-command. We deliberately do


### PR DESCRIPTION
## Problem

`/remote-control` was absent from the Claude Code slash menu, and `claude remote-control` (and other CLI subcommands) errored with `Unknown argument: <plugindir>`. Two independent root causes.

## Root cause 1 — telemetry var hid the slash command

`DISABLE_TELEMETRY="1"` in `settings.env` disables Claude Code's GrowthBook **feature-flag evaluation**, which Remote Control requires. Running the raw binary printed it plainly:

```
Error: Remote Control requires feature-flag evaluation, which is disabled
because DISABLE_TELEMETRY is set. Unset it (or run in a shell without it)
to use Remote Control.
```

The prior fix (`3eb12da8`) dropped the `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` umbrella but kept `DISABLE_TELEMETRY`, which still gates feature flags.

**Fix:** drop `DISABLE_TELEMETRY`; suppress the superpowers brainstorm beacon (its original purpose) via the dedicated `SUPERPOWERS_DISABLE_TELEMETRY` switch (`server.cjs:108`). OTel usage export stays off (opt-in, unset) → no telemetry regression.

## Root cause 2 — plugin wrapper breaks CLI subcommands

The home-manager module wraps the binary with `--plugin-dir` injected into **every** invocation (it's how `mcpServers`/`lspServers` config is delivered). Subcommands reject `--plugin-dir`. The module's `finalPackage` is `readOnly`/`internal`, so it can't be overridden.

**Fix:** nest a subcommand-aware dispatcher inside `programs.claude-code.package`. Its `bin/claude` peels the module-injected flags and forwards them only for the bare REPL / prompt path, stripping them when a subcommand follows. Real entrypoint preserved as `bin/.claude-real`.

## Verification

- Built `ali-desktop` claude-code `finalPackage`; wrapper chain `module → dispatcher → .claude-real` confirmed.
- `claude remote-control` no longer says `Unknown argument` (hits the telemetry gate, removed by this PR); `claude mcp --help` routes cleanly.
- Post-`switch`: `/remote-control` in slash menu, plugins + MCP/LSP still load, beacon stays suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)