### PR TITLE
feat(ssh): route git@codeberg.org through id_personal.pub

### DIFF
--- a/home/programs/ssh/default.nix
+++ b/home/programs/ssh/default.nix
@@ -199,6 +199,11 @@
           IdentityFile ~/.ssh/id_personal.pub
           IdentitiesOnly yes
 
+        Host codeberg.org
+          User git
+          IdentityFile ~/.ssh/id_personal.pub
+          IdentitiesOnly yes
+
         ${if azureDevopsRsaKey != "" then ''
         Host ssh.dev.azure.com
           User git


### PR DESCRIPTION
Codeberg had no SSH config block, so it fell back to the wildcard `Host *` 1Password agent and could offer the wrong identity. Pin `codeberg.org` to `~/.ssh/id_personal.pub` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)