### PR TITLE
ci: block fork-PR code on the home self-hosted runner

### DIFF
--- a/.github/workflows/build-and-cache.yaml
+++ b/.github/workflows/build-and-cache.yaml
@@ -118,7 +118,10 @@ jobs:
   build-desktops:
     runs-on: home-nix-builder-amd64
     timeout-minutes: 1440
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Backstop: never run fork-PR code on the home self-hosted runner, even if a
+    # `pull_request` trigger is added here by mistake. Inert for push events
+    # (github.event.pull_request is null → null != true → true).
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && github.event.pull_request.head.repo.fork != true }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build-installer-iso.yaml
+++ b/.github/workflows/build-installer-iso.yaml
@@ -30,6 +30,9 @@ jobs:
   build-iso:
     runs-on: home-nix-builder-amd64
     timeout-minutes: 240
+    # Backstop: never run fork-PR code on the home self-hosted runner, even if a
+    # `pull_request` trigger is added here by mistake. Inert for push events.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Why

`nix-config` is a **public** repo whose CI runs on the home self-hosted runner `home-nix-builder-amd64` (inside the home network). Part of hardening that runner against a pull-request author executing code in the home network.

## What

Fork-guards on both self-hosted jobs (`build-desktops` in build-and-cache, `build-iso` in build-installer-iso):

```yaml
if: ${{ github.event.pull_request.head.repo.fork != true }}
```

Inert for the current push/workflow_dispatch triggers (`github.event.pull_request` is null → passes), but a backstop so a future accidental `pull_request` trigger can't run fork-PR code on the runner.

## Related (separate repos)

- **Terraform Actions-security enforcer** (fork-PR approval → `all_external_contributors`, read-only token, allowed-actions allowlist, branch ruleset) now lives in the **`terraform`** repo under `github/` (branch `feat/github-repo-security`) — pillar 1, prevent execution, fleet-wide.
- **Runner containment** (Cilium egress deny-LAN NetworkPolicy + pod capability/seccomp hardening) in **`home-cluster`** PR #1278 — pillar 2, contain execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)