### PR TITLE
NVENC GPU passthrough for the GTX 1070 (hkh1 + k8s-master)

### DIFF
--- a/flake-modules/hosts/home-k8s-master-1/default.nix
+++ b/flake-modules/hosts/home-k8s-master-1/default.nix
@@ -58,12 +58,11 @@ in {
           enable = true;
           driverPackage = config.boot.kernelPackages.nvidiaPackages.legacy_580;
           # Uncap concurrent NVENC sessions (byte-patches libnvidia-encode.so).
-          # Off by default: the stock driver already allows 5 concurrent encode
-          # sessions, and enabling this forces a LOCAL driver rebuild (the
-          # patched .so is not in the binary cache). Flip to true only if you
-          # genuinely need >5 simultaneous transcodes. Verified to patch
-          # 580.173.02 exactly once (see modules/nvidia-transcode).
-          nvencUnlock = false;
+          # ON 2026-07-21: lifts the stock 5-session consumer cap so pharos'
+          # NVENC probe can ramp to its full 8 permits on the 1070. Forces a
+          # LOCAL driver rebuild (the patched .so is not in the binary cache).
+          # Verified to patch 580.173.02 exactly once (see modules/nvidia-transcode).
+          nvencUnlock = true;
         };
 
         boot.initrd.kernelModules = [ "amdgpu" ];

--- a/flake-modules/hosts/home-k8s-master-1/default.nix
+++ b/flake-modules/hosts/home-k8s-master-1/default.nix
@@ -65,6 +65,28 @@ in {
           nvencUnlock = true;
         };
 
+        # Discover GPUs via NVML directly instead of the default `auto` probe.
+        # `auto` additionally sniffs for WSL/Tegra/CSV environments, which this
+        # headless x86 passthrough node is not — `nvml` is the exact, minimal
+        # mode for a normal discrete GPU and skips those pointless probes.
+        # (extraArgs can't set this: it only appends a duplicate flag and
+        # nvidia-ctk honours the first; `discovery-mode` is the replacing knob.)
+        hardware.nvidia-container-toolkit.discovery-mode = "nvml";
+
+        # Put nvidia-container-runtime on k3s' PATH so k3s' startup
+        # auto-detection templates a `nvidia` containerd runtime (in the
+        # correct config version for its bundled containerd). NixOS'
+        # nvidia-container-toolkit installs the runtime into the store but not
+        # onto k3s' (minimal) service PATH, so without this k3s never sees it:
+        # the `nvidia` RuntimeClass resolves to a handler containerd doesn't
+        # have, and a `runtimeClassName: nvidia` pod fails to start.
+        # NB: the runtime binary lives in the package's `tools` OUTPUT (the
+        # default output only ships nvidia-ctk), so getOutput "tools" — the
+        # same reference the nixpkgs module uses for the runtime hook.
+        systemd.services.k3s.path = [
+          (lib.getOutput "tools" config.hardware.nvidia-container-toolkit.package)
+        ];
+
         boot.initrd.kernelModules = [ "amdgpu" ];
 
         # NFS client (mount.nfs) so kubelet can mount NFS PersistentVolumes —

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-k8s-master-1.xml.nix
@@ -215,39 +215,27 @@
         <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
       </rng>
       <!-- GTX 1070 (Pascal, GP104) passthrough for NVENC transcode on k3s.
-           STILL DISABLED (commented) until the card is physically seated: the
-           <source> host PCI addresses below are PLACEHOLDERS. libvirt refuses to
-           start a domain whose managed hostdev source address matches no device,
-           so leaving this commented keeps the VM (and the k3s control plane it
-           runs) bootable through the pre-hardware deploy.
-
-           TO ARM after seating the card:
-             1. On home-kvm-hypervisor-1: `lspci -nn -D | grep -i nvidia`
-                → note the VGA function (…:NN:00.0) and its HDMI-audio sibling
-                (…:NN:00.1). Confirm both sit in their own clean IOMMU group:
-                `for d in /sys/kernel/iommu_groups/*/devices/*; do ...` (only the
-                two GPU functions may share the group).
-             2. Set both <source> addresses below to the real bus/slot/function.
-             3. Uncomment this block.
-           Host binds them to vfio-pci at boot via modules.vfioIsolate (IDs
+           ARMED 2026-07-21: card seated at host 82:00.0 (VGA 10de:1b81) +
+           82:00.1 (HDMI audio 10de:10f0), confirmed alone in IOMMU group 30.
+           Host binds both to vfio-pci at boot via modules.vfioIsolate (IDs
            10de:1b81 + 10de:10f0), so managed='yes' hand-off is clean. The two
            functions are presented to the guest as one multifunction device
            (VGA fn0 + audio fn1) on a dedicated pcie-root-port. A Linux guest
-           needs no <kvm><hidden/> / vendor-id spoof (that is a Windows Code 43
-           workaround only).
+           needs no <kvm><hidden/> / vendor-id spoof (Windows Code 43 only).
+           NB: host address is NOT stable across card add/remove/move — re-verify
+           `lspci -Dnn | grep -i nvidia` and update <source> after physical work. -->
       <hostdev mode='subsystem' type='pci' managed='yes'>
         <source>
-          <address domain='0x0000' bus='0xNN' slot='0x00' function='0x0'/>
+          <address domain='0x0000' bus='0x82' slot='0x00' function='0x0'/>
         </source>
         <address type='pci' domain='0x0000' bus='0x07' slot='0x00' function='0x0' multifunction='on'/>
       </hostdev>
       <hostdev mode='subsystem' type='pci' managed='yes'>
         <source>
-          <address domain='0x0000' bus='0xNN' slot='0x00' function='0x1'/>
+          <address domain='0x0000' bus='0x82' slot='0x00' function='0x1'/>
         </source>
         <address type='pci' domain='0x0000' bus='0x07' slot='0x00' function='0x1'/>
       </hostdev>
-      -->
     </devices>
   </domain>
 ''

--- a/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
+++ b/libvirtd/home-kvm-hypervisor-1/domains/home-storage-server-1.xml.nix
@@ -203,19 +203,24 @@
       <model type="virtio" heads="1" primary="yes"/>
       <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
     </video>
-    <!-- SAS3008 HBA passthrough. New EPYC/ROMED8-2T board: one physical dual-controller
-         card behind a PLX PEX 8724 switch enumerates as TWO SAS3008 functions at host
-         84:00.0 and 86:00.0 (was a single 05:00.0 on the old board). Both bound to
-         vfio-pci by vfio-pci.ids=1000:0097; the pool drives are split across both, so
-         pass both. Guest <address> omitted so libvirt auto-assigns free pcie-root-ports. -->
+    <!-- SAS3008 HBA passthrough. One physical dual-controller card behind a PLX PEX
+         8724 switch enumerates as TWO SAS3008 functions. Host addresses are NOT stable
+         across hardware changes: moving the HBA to a different slot for the GTX 1070
+         install (2026-07-21) changed the pair from 84:00.0/86:00.0 to 03:00.0/05:00.0.
+         Verify with `lspci -Dnn | grep 1000:0097` after any card add/remove/move. Bound
+         to vfio-pci by
+         device ID (vfio-pci.ids=1000:0097, address-independent), but this <hostdev>
+         pins host address, so it MUST track lspci after any card add/remove. The pool
+         drives are split across both functions, so pass both. Guest <address> omitted
+         so libvirt auto-assigns free pcie-root-ports. -->
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-        <address domain='0x0000' bus='0x84' slot='0x00' function='0x0'/>
+        <address domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
       </source>
     </hostdev>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-        <address domain='0x0000' bus='0x86' slot='0x00' function='0x0'/>
+        <address domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
       </source>
     </hostdev>
     <redirdev bus="usb" type="spicevmc">


### PR DESCRIPTION
Brings up the GTX 1070 (Pascal, GP104) installed in home-kvm-hypervisor-1 for pharos NVENC transcode.

- **fix(hkh1)**: repoint the storage-server SAS HBA passthrough after the slot move (`84/86` → `03/05` host bus) — this is the media-outage fix (mergerfs found no branch → NFS ENOENT → pharos `exit status 32`). Already deployed via `nixos-rebuild switch`; this commits it.
- **feat(hkh1)**: arm the 1070 `<hostdev>` to host `82:00.0`/`82:00.1` (IOMMU group 30, vfio-pci by ID). Takes effect on next VM cold-restart.
- **feat(hkh1)**: enable `modules.nvidiaTranscode.nvencUnlock` (keylase patch, lifts the 5-session cap so the NVENC probe ramps to 8 permits).

Deploy in flight via deploy-rs. GPU attaches to the node on the next VM cold-restart (needs the LUKS password at boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)