### PR TITLE
fix(hkh1): make runtimeClassName:nvidia pods run (cdi mode + runc + uuid)

### DIFF
--- a/flake-modules/hosts/home-k8s-master-1/default.nix
+++ b/flake-modules/hosts/home-k8s-master-1/default.nix
@@ -73,6 +73,13 @@ in {
         # nvidia-ctk honours the first; `discovery-mode` is the replacing knob.)
         hardware.nvidia-container-toolkit.discovery-mode = "nvml";
 
+        # Name CDI devices by GPU UUID (nvidia.com/gpu=GPU-<uuid>) to match how
+        # the k8s device plugin advertises + requests them. The default `index`
+        # strategy names them nvidia.com/gpu=0, so the runtime can't resolve the
+        # plugin's UUID reference ("unresolvable CDI devices") and every GPU pod
+        # fails to create.
+        hardware.nvidia-container-toolkit.device-name-strategy = "uuid";
+
         # Put nvidia-container-runtime on k3s' PATH so k3s' startup
         # auto-detection templates a `nvidia` containerd runtime (in the
         # correct config version for its bundled containerd). NixOS'
@@ -255,6 +262,33 @@ in {
             };
           };
         };
+
+        # nvidia-container-runtime config for the k3s/containerd path. The
+        # upstream nvidia-container-toolkit module only writes this under
+        # `virtualisation.docker.enableNvidia`, so with k3s it is absent and
+        # the runtime defaults to LEGACY mode → it shells out to
+        # nvidia-container-cli (libnvidia-container), which this headless
+        # NixOS node does not ship → `nvidia-container-runtime` exits 2 and
+        # every `runtimeClassName: nvidia` pod fails to create. Force `cdi`
+        # mode: the runtime then injects the GPU purely from the CDI spec the
+        # generator wrote to /run/cdi (no libnvidia-container needed).
+        environment.etc."nvidia-container-runtime/config.toml".text = ''
+          disable-require = true
+          [nvidia-container-runtime]
+          mode = "cdi"
+          # nvidia-container-runtime is a thin wrapper that, after injecting
+          # the GPU, execs a low-level OCI runtime. It searches PATH for
+          # [runc crun] by default, but the containerd shim invokes it with a
+          # PATH that doesn't include k3s' bundled runc → "no runtime binary
+          # found". Pin an explicit runc from nixpkgs (OCI-standard; cgroup
+          # flags still come from the containerd runtime options).
+          runtimes = ["${lib.getExe pkgs.runc}"]
+          [nvidia-container-runtime.modes.cdi]
+          default-kind = "nvidia.com/gpu"
+          spec-dirs = ["/run/cdi", "/etc/cdi"]
+          [nvidia-ctk]
+          path = "${lib.getExe' config.hardware.nvidia-container-toolkit.package "nvidia-ctk"}"
+        '';
 
         system.stateVersion = "24.05";
 


### PR DESCRIPTION
Follow-up to #171. After k3s templated the `nvidia` containerd runtime, GPU pods still failed to create; three node-config fixes make them run:

- **cdi mode**: write `/etc/nvidia-container-runtime/config.toml` with `mode = "cdi"` (the upstream module only writes it for docker). Legacy mode shelled out to `nvidia-container-cli`/libnvidia-container (not shipped) → `nvidia-container-runtime` exit 2.
- **explicit runc**: the runtime wrapper couldn't find a low-level runtime (`no runtime binary found from candidate list: [runc crun]`) — the containerd shim's PATH lacks k3s' bundled runc. Pinned `${pkgs.runc}`.
- **uuid device names**: `device-name-strategy = "uuid"` so the CDI spec matches the device plugin's `nvidia.com/gpu=GPU-<uuid>` request (default `index` → "unresolvable CDI devices").

**Proven end-to-end:** device plugin advertises `nvidia.com/gpu: 1`, pharos pod binds the GPU, boot probe logs `hardware encoder confirmed by trial encode, device Nvenc:0, sessions 8`.

Already deployed to home-k8s-master-1 via deploy-rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)