### PR TITLE
fix(storage-server): mergerfs pool resilience (2026-07-21 playback outage)

### DIFF
--- a/flake-modules/hosts/home-storage-server-1/default.nix
+++ b/flake-modules/hosts/home-storage-server-1/default.nix
@@ -141,20 +141,47 @@ in {
             Type = "oneshot";
             RemainAfterExit = true;
           };
-          path = [ pkgs.util-linux pkgs.coreutils pkgs.attr pkgs.nfs-utils ];
+          path = [ pkgs.util-linux pkgs.coreutils pkgs.gnugrep pkgs.attr pkgs.nfs-utils ];
           script = ''
-            # Rescan all SCSI hosts for new devices
-            for host in /sys/class/scsi_host/host*/scan; do
-              echo "- - -" > "$host"
-            done
+            # Only do the DESTRUCTIVE SCSI rescan when a branch disk is actually
+            # missing. Echoing "- - -" to every scsi_host forces the LSI HBA to
+            # re-run discovery, which on this passthrough card emits a
+            # `sata affiliation conflict` storm and can transiently drop a live
+            # SATA drive behind the expander. When paired with the `systemctl
+            # daemon-reload` this service USED to run, that reload re-evaluated
+            # the fstab-generated media-storage.mount mid-device-flux and
+            # UNMOUNTED the healthy pool — NFS then served empty stub dirs and
+            # every client got ENOENT (silent total playback outage, 2026-07-21;
+            # boot 0: pool mounted 17:46:18 -> daemon-reload 17:46:22 -> pool
+            # Deactivated 17:46:23, never recovered). So: gate the rescan, and
+            # NEVER daemon-reload here (the branch .mount units are static, built
+            # from fileSystems — they already exist; starting them needs no
+            # reload). The media-pool-watchdog below is the catch-all if the pool
+            # ever drops anyway.
+            expected=${toString (builtins.length mergerfsBranchMounts)}
+            branches_mounted() {
+              findmnt -rn -o TARGET 2>/dev/null | grep -c '^/media/disks/' || true
+            }
 
-            # Wait for udev to settle after rescan
-            ${pkgs.systemd}/bin/udevadm settle --timeout=30
+            if [ "$(branches_mounted)" -lt "$expected" ]; then
+              echo "branches $(branches_mounted)/$expected mounted -> SCSI rescan for late disks"
+              for host in /sys/class/scsi_host/host*/scan; do
+                echo "- - -" > "$host"
+              done
+              # Wait for udev to settle after rescan
+              ${pkgs.systemd}/bin/udevadm settle --timeout=30
+              # Start any disk mounts that are now satisfiable (NO daemon-reload).
+              systemctl start --all 'media-disks-*.mount' 'media-parity-*.mount' 2>/dev/null || true
+            else
+              echo "all $expected branches mounted -> skip destructive SCSI rescan"
+            fi
 
-            # Reload systemd to pick up any new device units, then
-            # start any disk mounts that are now satisfiable
-            systemctl daemon-reload
-            systemctl start --all 'media-disks-*.mount' 'media-parity-*.mount' 2>/dev/null || true
+            # Ensure the pool is up (an earlier event may have dropped it). We
+            # only ever START it here, never restart: if it is down nothing holds
+            # it open so the mount succeeds; if it is up we no-op.
+            if ! findmnt -t fuse.mergerfs /media/storage >/dev/null 2>&1; then
+              systemctl start media-storage.mount || true
+            fi
 
             # Re-add branches at runtime for any disk that appeared only after
             # the pool mounted. A `systemctl restart media-storage.mount` can

--- a/flake-modules/hosts/home-storage-server-1/default.nix
+++ b/flake-modules/hosts/home-storage-server-1/default.nix
@@ -297,6 +297,51 @@ in {
           wants = [ "media-storage.mount" ];
         };
 
+        # Catch-all self-heal: if the mergerfs pool ever drops while the box is
+        # up (a SAS `sata affiliation conflict` flap, a stray daemon-reload, a
+        # branch bounce), NFS keeps serving the now-empty mountpoint stubs and
+        # every client gets ENOENT until someone manually remounts — a SILENT
+        # total outage (2026-07-21: the pool sat dead for ~2.5h before anyone
+        # noticed nothing played). This watchdog detects the pool being gone and
+        # brings it straight back, so the failure self-resolves server-side in
+        # <=60s instead of needing an ssh in. It only ever STARTs the mount (the
+        # pool is unmounted when unhealthy, so nothing holds it open — safe, and
+        # it no-ops the instant the pool is a live fuse.mergerfs mount again).
+        systemd.services.media-pool-watchdog = {
+          description = "Heal the mergerfs pool + NFS export if it drops";
+          after = [ "media-storage.mount" ];
+          path = [ pkgs.util-linux pkgs.coreutils pkgs.attr pkgs.nfs-utils pkgs.systemd ];
+          serviceConfig = {
+            Type = "oneshot";
+          };
+          script = ''
+            if findmnt -t fuse.mergerfs /media/storage >/dev/null 2>&1; then
+              exit 0
+            fi
+            echo "mergerfs pool /media/storage is DOWN -> healing"
+            systemctl start media-disks-ready.service 2>/dev/null || true
+            systemctl start media-storage.mount || true
+            if findmnt -t fuse.mergerfs /media/storage >/dev/null 2>&1; then
+              # Re-export so a now-present subtree is served rather than ENOENT'd,
+              # and re-normalize the branch top-dir ownership/ACLs.
+              exportfs -ra 2>/dev/null || true
+              systemctl start media-branch-normalize.service 2>/dev/null || true
+              echo "mergerfs pool healed"
+            else
+              echo "mergerfs pool still down after heal attempt" >&2
+            fi
+          '';
+        };
+        systemd.timers.media-pool-watchdog = {
+          description = "Periodic mergerfs pool health check";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnBootSec = "90s";
+            OnUnitActiveSec = "60s";
+            AccuracySec = "10s";
+          };
+        };
+
         environment = {
           pathsToLink = [ "/share/zsh" ];
 


### PR DESCRIPTION
## Why

2026-07-21 total playback outage: pharos/jellyfin served nothing. Root cause was **not** the app or the new GPU — the mergerfs pool on home-storage-server-1 silently died at boot, so NFS served empty mountpoint stub dirs and every client `open()` returned ENOENT.

### Root cause (boot 0)
```
17:46:18  Mounted /media/storage            (pool up, all 16 branches)
17:46:20  Starting scsi-rescan-and-mount    (after multi-user.target)
17:46:22  Reload requested (scsi-rescan-and-mount) -> Reloading...   <- its `systemctl daemon-reload`
17:46:23  media-storage.mount: Deactivated successfully              <- POOL KILLED, never recovered
```
The `scsi-rescan-and-mount` fallback ran an **unconditional destructive SCSI rescan** (`echo "- - -"` to every scsi_host) — which on the passed-through LSI HBA triggers a `sata affiliation conflict` discovery storm that transiently drops a live SATA drive behind the expander — **then `systemctl daemon-reload`**, which re-evaluated the fstab-generated `media-storage.mount` mid-device-flux and unmounted the healthy pool.

## Changes
1. **fix**: gate the SCSI rescan on a branch actually being missing (count mounted `/media/disks/*` vs expected), and **drop the `daemon-reload`** (the pool-killer; branch `.mount` units are static, need no reload). Also stops provoking the affiliation storm on every boot.
2. **feat**: `media-pool-watchdog` timer (90s boot / 60s interval) that detects the pool not being a live `fuse.mergerfs` mount and heals it (start mount + `exportfs -ra` + re-normalize) — so any future flap self-resolves in <=60s instead of a silent multi-hour outage.

## Validation
- `nix build .#nixosConfigurations.home-storage-server-1.config.system.build.toplevel` — **exit 0**.
- Immediate outage already restored live (`systemctl start media-storage.mount`; pods recreated for fresh NFS mounts).

## Deploy
`deploy-rs` switch to home-storage-server-1 (no reboot needed; unit changes apply on switch, watchdog timer starts immediately). The rescan fix only changes boot behaviour on the next reboot.

## Residual / follow-up
- The `sata affiliation conflict` itself is chronic HBA/expander discovery noise but non-fatal (drives read fine, zero I/O errors); the damage was only via the rescan+reload, now removed.
- k8s NFS clients that mount during a pool-down window still cache the empty root and need a pod restart (companion home-cluster PR fixes the single-GPU rollout deadlock that made that restart painful).