### PR TITLE
feat(hetzner): automate k3s SQLite datastore compaction and backup

### DIFF
--- a/flake-modules/hetzner-tests.nix
+++ b/flake-modules/hetzner-tests.nix
@@ -427,6 +427,42 @@ in
               wrapper = machine.succeed(f"cat {m.group(1)}")
               assert "set -euo pipefail" in wrapper, "heal wrapper must set -e (loud failure) [B34]"
 
+          with subtest("datastore maintenance + backup units exist and are role-guarded [2026-07-30]"):
+              # The 2026-07-30 outage was an unbounded kine/SQLite datastore that
+              # nothing compacted and nothing watched. These units are the fix, so
+              # guard them the way B30/V27 guard the rest: assert on the REAL unit.
+              for svc in ("k3s-datastore-maintenance", "k3s-datastore-backup"):
+                  unit = machine.succeed(f"systemctl cat {svc}.service")
+                  # Must never run on a worker — stopping k3s there would be an
+                  # outage for no reason, and there is no server datastore to fix.
+                  assert 'ROLE:-agent' in unit, f"{svc} must role-guard to server only: {unit}"
+                  # Timer must be installed, else the automation silently never runs.
+                  machine.succeed(f"systemctl cat {svc}.timer")
+                  props = machine.succeed(f"systemctl show {svc}.timer -p Persistent")
+                  assert "Persistent=yes" in props, \
+                      f"{svc}.timer must be Persistent (a node down at the scheduled time must still run): {props}"
+
+              # Maintenance must never be killed part-way through a VACUUM: an
+              # interrupted vacuum on a multi-GB datastore is how you turn a slow
+              # cluster into a corrupt one.
+              props = machine.succeed(
+                  "systemctl show k3s-datastore-maintenance.service -p TimeoutStartUSec"
+              )
+              assert "TimeoutStartUSec=infinity" in props, \
+                  f"maintenance must not time out mid-vacuum: {props}"
+
+              # It stops k3s, so it MUST restart it unconditionally — without the
+              # trap an aborted run leaves the control plane down indefinitely.
+              unit = machine.succeed("systemctl cat k3s-datastore-maintenance.service")
+              m = re.search(r'ExecStart=(/nix/store/\S+)', unit)
+              assert m, f"no maintenance ExecStart: {unit}"
+              script = machine.succeed(f"cat {m.group(1)}")
+              assert "trap restart_k3s EXIT" in script, \
+                  "maintenance must restart k3s via an EXIT trap even when compaction fails"
+
+              # On an agent the guard should short-circuit cleanly, not error.
+              machine.succeed("systemctl start k3s-datastore-maintenance.service")
+
           with subtest("post-quantum SSH KEX offered [V12]"):
               kex = machine.succeed("sshd -T 2>/dev/null | grep -i '^kexalgorithms'")
               assert "mlkem768x25519-sha256" in kex, f"PQC KEX missing: {kex}"

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -561,8 +561,15 @@
 
         [ -f "$DB" ] || { echo "no datastore at $DB — nothing to do"; exit 0; }
 
-        SIZE=$(stat -c %s "$DB")
-        echo "datastore size: $SIZE bytes (threshold $THRESHOLD_BYTES)"
+        # Measure the DB *and* its WAL. In the 2026-07-30 incident the WAL was
+        # the LARGER half — 21 GB against a 7.6 GB db — because SQLite cannot
+        # truncate it while a reader is open and kine holds long-running watch
+        # reads. A trigger on state.db alone would sail straight past a runaway
+        # WAL, which is the same outage with the sizes swapped.
+        DB_SIZE=$(stat -c %s "$DB")
+        WAL_SIZE=$(stat -c %s "$DB-wal" 2>/dev/null || echo 0)
+        SIZE=$((DB_SIZE + WAL_SIZE))
+        echo "datastore: db=$DB_SIZE wal=$WAL_SIZE total=$SIZE (threshold $THRESHOLD_BYTES)"
         if [ "$SIZE" -lt "$THRESHOLD_BYTES" ]; then
           echo "under threshold — no maintenance needed, k3s untouched"; exit 0
         fi
@@ -585,8 +592,19 @@
 
         # Fold the WAL back in and truncate it. With k3s stopped there are no
         # readers, so this can finally reclaim the WAL that grows without bound
-        # under live watch traffic.
+        # under live watch traffic. Cheap — seconds — and on its own enough when
+        # the WAL was what crossed the threshold.
         sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+        # Re-measure. If truncating the WAL got us back under, stop here: the
+        # row-delete below is the expensive part (40 minutes on the 7.6 GB
+        # datastore in the 2026-07-30 incident) and every second of it is a full
+        # outage, since stopping k3s takes containerd and all pods with it.
+        DB_SIZE=$(stat -c %s "$DB")
+        if [ "$DB_SIZE" -lt "$THRESHOLD_BYTES" ]; then
+          echo "checkpoint alone sufficed (db=$DB_SIZE) — skipping compaction"
+          exit 0
+        fi
 
         # Drop every superseded revision, keeping the newest row per key. This is
         # the compaction kine failed to do. Deleted keys keep their tombstone row

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -505,5 +505,178 @@
         exec ${pkgs.bash}/bin/bash ${healScript}
       '';
     };
+
+    # Datastore maintenance [2026-07-30 outage]. k3s on SQLite has TWO unbounded
+    # growth paths and no built-in remedy for either:
+    #
+    #  1. kine keeps every revision of every key in the `kine` table and relies on
+    #     its own periodic compaction. When that stalls, nothing notices — the
+    #     table just grows. On 2026-07-30 state.db reached 7.6 GB backing only
+    #     ~3000 live objects, of which just 323 MB was reclaimable free pages:
+    #     the rest was genuinely-live superseded revisions — 2,324,353 rows over
+    #     94,345 distinct keys.
+    #
+    #     The churn is almost entirely leader-election Leases, NOT scanner report
+    #     objects as first assumed. Every controller renews its Lease every few
+    #     seconds and each renewal writes a new revision; the top keys were
+    #     /registry/leases/ente/ente-db (163k revisions), the four kyverno
+    #     controllers (~90k each), envoy-gateway (83k) and the six flux-system
+    #     leader-election leases (~75k each). Nothing is misconfigured — this is
+    #     the steady-state write rate of the platform, so compaction has to keep
+    #     up or the file grows without bound.
+    #  2. SQLite never shrinks the file on its own (DELETE only frees pages) and
+    #     never truncates the WAL while a reader is open. kine holds long-running
+    #     watch reads, so the WAL had grown to 21 GB.
+    #
+    # Together those drove datastore writes to 45s, failed the API server's readyz
+    # etcd check, flapped the node NotReady and took down ingress-served apps.
+    #
+    # This unit is SIZE-TRIGGERED, not unconditionally periodic: on a healthy
+    # cluster it inspects the file and exits in milliseconds with no downtime. It
+    # only stops k3s when the datastore has actually bloated past the threshold.
+    k3s-datastore-maintenance = {
+      description = "Compact + vacuum the k3s SQLite datastore when it bloats [2026-07-30]";
+      # Explicit PATH — NixOS strips defaults and a bare command here would exit
+      # 127 silently, which is exactly how k3s-node-heal shipped broken [B27].
+      path = with pkgs; [ sqlite coreutils systemd util-linux ];
+      # A vacuum of a multi-GB DB on a small swapping node is slow; never let
+      # systemd kill it half-way through.
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "infinity";
+      };
+      script = ''
+        set -euo pipefail
+
+        DB=/var/lib/rancher/k3s/server/db/state.db
+        # Act at 2 GB. Healthy is well under 1 GB; by 4 GB the API server is
+        # already failing readyz, so this leaves real headroom to act in.
+        THRESHOLD_BYTES=$((2 * 1024 * 1024 * 1024))
+
+        for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
+        source /etc/karpenter-node.conf
+        if [ "''${ROLE:-agent}" != "server" ]; then
+          echo "ROLE=''${ROLE:-agent}, not server — skipping datastore maintenance"; exit 0
+        fi
+
+        [ -f "$DB" ] || { echo "no datastore at $DB — nothing to do"; exit 0; }
+
+        SIZE=$(stat -c %s "$DB")
+        echo "datastore size: $SIZE bytes (threshold $THRESHOLD_BYTES)"
+        if [ "$SIZE" -lt "$THRESHOLD_BYTES" ]; then
+          echo "under threshold — no maintenance needed, k3s untouched"; exit 0
+        fi
+
+        echo "over threshold — compacting (k3s will be stopped)"
+        systemctl stop k3s-server-bootstrap.service
+
+        # Always bring the control plane back, even if compaction fails. Without
+        # this an aborted vacuum would leave the cluster down indefinitely.
+        restart_k3s() { echo "restarting k3s"; systemctl start k3s-server-bootstrap.service || true; }
+        trap restart_k3s EXIT
+
+        # Safety copy on the EPHEMERAL root disk, not the state volume: the state
+        # volume is what we are trying to free, and root has far more headroom.
+        # Only needs to outlive this run — the durable copy is the backup timer.
+        SAFETY=/var/tmp/k3s-datastore-premaintenance.db
+        rm -f "$SAFETY"
+        sqlite3 "$DB" ".backup '$SAFETY'"
+        echo "safety copy: $(stat -c %s "$SAFETY") bytes at $SAFETY"
+
+        # Fold the WAL back in and truncate it. With k3s stopped there are no
+        # readers, so this can finally reclaim the WAL that grows without bound
+        # under live watch traffic.
+        sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+        # Drop every superseded revision, keeping the newest row per key. This is
+        # the compaction kine failed to do. Deleted keys keep their tombstone row
+        # (it is the MAX for that name) so watchers still observe the deletion.
+        sqlite3 "$DB" "DELETE FROM kine WHERE id NOT IN (SELECT MAX(id) FROM kine GROUP BY name);"
+
+        # DELETE only moves pages to the freelist; VACUUM is what shrinks the file.
+        sqlite3 "$DB" "VACUUM;"
+
+        echo "datastore after maintenance: $(stat -c %s "$DB") bytes"
+      '';
+    };
+
+    # Durable recovery point for the datastore. SPEC T18-DBDONE deferred this as
+    # "mostly GitOps-reconstructible", but the 2026-07-30 incident showed the real
+    # value is different: without a backup, ANY repair to a bloated or corrupted
+    # state.db is performed without a net. k3s's --etcd-snapshot does not apply on
+    # SQLite, so roll our own.
+    #
+    # `.backup` is SQLite's online backup API — safe against a live, running k3s,
+    # so this needs no downtime at all. Backups land on the LUKS volume, which has
+    # delete protection and survives a cattle replace [V21].
+    k3s-datastore-backup = {
+      description = "Online backup of the k3s SQLite datastore";
+      path = with pkgs; [ sqlite coreutils findutils ];
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "3600s";
+      };
+      script = ''
+        set -euo pipefail
+
+        DB=/var/lib/rancher/k3s/server/db/state.db
+        DEST=/var/lib/rancher/k3s/server/db-backups
+        KEEP=7
+
+        for i in $(seq 1 60); do [ -f /etc/karpenter-node.conf ] && break; sleep 2; done
+        source /etc/karpenter-node.conf
+        if [ "''${ROLE:-agent}" != "server" ]; then
+          echo "ROLE=''${ROLE:-agent}, not server — skipping datastore backup"; exit 0
+        fi
+
+        [ -f "$DB" ] || { echo "no datastore at $DB — nothing to back up"; exit 0; }
+
+        # Refuse to back up a bloated datastore: copying multi-GB files is exactly
+        # what fills the state volume and triggers the DiskPressure/Kyverno
+        # deadlock [2026-07-22]. Maintenance must shrink it first.
+        SIZE=$(stat -c %s "$DB")
+        if [ "$SIZE" -gt $((4 * 1024 * 1024 * 1024)) ]; then
+          echo "datastore is $SIZE bytes — too large to back up safely; run k3s-datastore-maintenance first" >&2
+          exit 1
+        fi
+
+        mkdir -p "$DEST"; chmod 0700 "$DEST"
+        STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+        sqlite3 "$DB" ".backup '$DEST/state-$STAMP.db'"
+        echo "wrote $DEST/state-$STAMP.db ($(stat -c %s "$DEST/state-$STAMP.db") bytes)"
+
+        # Retain the newest $KEEP only — unbounded backups are another way to fill
+        # the very volume this is meant to protect.
+        ls -1t "$DEST"/state-*.db | tail -n +$((KEEP + 1)) | while read -r old; do
+          echo "pruning $old"; rm -f "$old"
+        done
+      '';
+    };
+  };
+
+  systemd.timers = {
+    # Daily size check. Cheap and silent when healthy — it only imposes downtime
+    # on the day the datastore has actually crossed the threshold, and the
+    # K3sDatastoreGrowing alert fires well before that so a human can pre-empt it.
+    k3s-datastore-maintenance = {
+      description = "Daily k3s datastore size check (compacts only when bloated)";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "*-*-* 04:00:00 UTC";
+        # Spread load and survive a node that was down at the scheduled time.
+        RandomizedDelaySec = "30m";
+        Persistent = true;
+      };
+    };
+
+    k3s-datastore-backup = {
+      description = "Daily online backup of the k3s datastore";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "*-*-* 03:00:00 UTC";
+        RandomizedDelaySec = "15m";
+        Persistent = true;
+      };
+    };
   };
 }

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -588,7 +588,8 @@
         SAFETY=/var/tmp/k3s-datastore-premaintenance.db
         rm -f "$SAFETY"
         sqlite3 "$DB" ".backup '$SAFETY'"
-        echo "safety copy: $(stat -c %s "$SAFETY") bytes at $SAFETY"
+        SAFETY_SIZE=$(stat -c %s "$SAFETY")
+        echo "safety copy: $SAFETY_SIZE bytes at $SAFETY"
 
         # Fold the WAL back in and truncate it. With k3s stopped there are no
         # readers, so this can finally reclaim the WAL that grows without bound

--- a/lib/hetzner-node-services.nix
+++ b/lib/hetzner-node-services.nix
@@ -606,9 +606,17 @@
     # state.db is performed without a net. k3s's --etcd-snapshot does not apply on
     # SQLite, so roll our own.
     #
-    # `.backup` is SQLite's online backup API — safe against a live, running k3s,
-    # so this needs no downtime at all. Backups land on the LUKS volume, which has
-    # delete protection and survives a cattle replace [V21].
+    # Uses `VACUUM INTO`, NOT `.backup`. Both are online and safe against a live
+    # k3s, but SQLite's `.backup` restarts the copy from the beginning whenever
+    # the source is written mid-copy — and kine's lease renewals write every few
+    # seconds, so it starves. Measured on this node: `.backup` reached 378 MB of
+    # a 550 MB datastore and then made no further progress at all.
+    #
+    # `VACUUM INTO` takes a single read snapshot and writes a compacted copy in
+    # one pass with no restart loop, and the output is defragmented as a bonus.
+    #
+    # Backups land on the LUKS volume, which has delete protection and survives a
+    # cattle replace [V21].
     k3s-datastore-backup = {
       description = "Online backup of the k3s SQLite datastore";
       path = with pkgs; [ sqlite coreutils findutils ];
@@ -641,8 +649,14 @@
         fi
 
         mkdir -p "$DEST"; chmod 0700 "$DEST"
+        # Clear any .partial left by a previous interrupted run, so they cannot
+        # accumulate and fill the state volume.
+        rm -f "$DEST"/*.partial
         STAMP=$(date -u +%Y%m%dT%H%M%SZ)
-        sqlite3 "$DB" ".backup '$DEST/state-$STAMP.db'"
+        # Write to a .partial name and rename only on success, so an interrupted
+        # run can never leave a truncated file that looks like a valid backup.
+        sqlite3 "$DB" "VACUUM INTO '$DEST/state-$STAMP.db.partial';"
+        mv "$DEST/state-$STAMP.db.partial" "$DEST/state-$STAMP.db"
         echo "wrote $DEST/state-$STAMP.db ($(stat -c %s "$DEST/state-$STAMP.db") bytes)"
 
         # Retain the newest $KEEP only — unbounded backups are another way to fill


### PR DESCRIPTION
## Context

On 2026-07-30 the Hetzner CP's k3s SQLite datastore ran away and wedged the control plane: `state.db` 7.6 GB plus a **21 GB WAL**, backing only ~3000 live objects. Writes stretched to 45s, the API server failed its `readyz` etcd check, the node flapped `NotReady`, and ingress-served apps started 502ing.

k3s-on-SQLite has two unbounded growth paths and no built-in remedy for either:

1. **kine keeps every revision per key** and relies on its own periodic compaction. That stalled unnoticed, leaving 2,324,353 rows over 94,345 keys — with only 323 MB of reclaimable freelist, so the bulk was *live* superseded revisions and a plain `VACUUM` would have reclaimed almost nothing.

   The churn driver is **leader-election Leases**, not scanner reports: every controller renews every few seconds and each renewal is a new revision. Top keys were `ente-db` (163k), the four kyverno controllers (~90k each), envoy-gateway (83k) and the six flux leader-election leases (~75k each). Nothing is misconfigured — that is the platform's steady-state write rate, so compaction has to keep up or the file grows forever.

2. **SQLite never truncates the WAL while a reader is open**, and kine holds long-running watch reads. The WAL reached ~3x the database.

Confirmed as a death spiral, not a broken component: once the datastore was compacted, kine's own compaction immediately resumed and pruned 94,345 rows down to 6,526 within minutes. It was outrun, not broken.

## Changes

**`k3s-datastore-maintenance`** — size-triggered at 2 GB, so a healthy cluster pays no downtime: it inspects the files and exits in ~50ms. Only when genuinely bloated does it stop k3s, take a safety copy, checkpoint+truncate the WAL, delete superseded revisions and `VACUUM`. An EXIT trap always restarts k3s, so a failed compaction cannot leave the control plane down.

**`k3s-datastore-backup`** — daily online backup. SPEC T18-DBDONE deferred this as "GitOps-reconstructible"; the real value is that without it, any repair to a bloated or corrupt `state.db` runs without a net.

Both role-guard to server. VM tests assert the units exist, are guarded, have installed `Persistent` timers, cannot be killed mid-vacuum, and restart k3s via the trap — the B30/V27 convention that previously caught PR #163 shipping absent.

## Three defects found by testing against the live cluster

- **`.backup` starves.** It restarts the copy from scratch whenever the source is written, and kine's lease renewals never stop. Measured: stalled at 378 MB of a 550 MB datastore with no further progress. It would never have completed while looking correctly configured — the worst failure mode for a backup. Now `VACUUM INTO`: 3.7s for a 527 MB output, `PRAGMA quick_check` = ok.
- **The trigger measured `state.db` only**, so a runaway WAL — the *larger* half of this outage — would have sailed past it. Not hypothetical: ten minutes after the repair the WAL had already regrown to 530 MB against a 555 MB database. Now measures both.
- **Straight to the row-delete.** The delete is the expensive part (40 minutes here) and every second is a full outage, since stopping k3s takes containerd and all pods with it. When the WAL is what crossed the threshold, truncating it is the whole fix. Now re-measures after the checkpoint and exits if that sufficed — turning the next trigger on this cluster from ~40 minutes into seconds.

## Verification

Installed live on the CP and exercised:
- no-op path: `db=555220992 wal=530173992 total=1085394984` → under threshold, returns in 51ms, k3s untouched
- backup path: 527 MB output in 3.7s, `quick_check` ok, 100,049 rows
- both timers armed (03:00 backup, 04:00 maintenance)

Module evaluates and the test file parses on this branch's `main` base.

Companion PR: alisonjenkins/home-cluster#1346 (alerting + off-box watcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7RMsz5bpsxcMqzM5Hijgf