### PR TITLE
fix(nix): drop the garnix binary cache, which has shut down

### DIFF
--- a/flake-modules/ami-images.nix
+++ b/flake-modules/ami-images.nix
@@ -284,12 +284,10 @@ let
         extra-substituters = [
           "https://cache.nixcache.org"
           "https://nix-community.cachix.org"
-          "https://cache.garnix.io"
         ];
         extra-trusted-public-keys = [
           "nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak="
           "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-          "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         ];
       };
       gc.options = lib.mkForce "--delete-older-than 7d";

--- a/flake-modules/hosts/download-server-1/default.nix
+++ b/flake-modules/hosts/download-server-1/default.nix
@@ -2025,7 +2025,6 @@ EOF
                 nix = [
                   "cache.nixcache.org"
                   "attic.xuyh0120.win"
-                  "cache.garnix.io"
                   "cache.nixos.org"
                   "channels.nixos.org"
                   "jovian.cachix.org"

--- a/flake-modules/hosts/installer-iso/default.nix
+++ b/flake-modules/hosts/installer-iso/default.nix
@@ -1139,12 +1139,10 @@ in
             extra-substituters = [
               "https://cache.nixcache.org"
               "https://nix-community.cachix.org"
-              "https://cache.garnix.io"
             ];
             extra-trusted-public-keys = [
               "nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak="
               "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-              "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
             ];
           };
 

--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -362,7 +362,6 @@ in
           substituters = lib.mkBefore [
             "https://cache.nixcache.org"
             "https://attic.xuyh0120.win/lantian"
-            "https://cache.garnix.io"
             "https://cache.nixos.org"
             "https://jovian.cachix.org"
             # Third-party daily builds of Jovian-NixOS `development` against
@@ -377,7 +376,6 @@ in
 
           trusted-public-keys = [
             "nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak="
-            "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
             "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
             # Verified via https://app.cachix.org/api/v1/cache/jovian.
             # The previous key here (mAWLjAxLNI3RiPXtAE24VSpamW0gUfnGzroKvA/x2yE=)


### PR DESCRIPTION
`cache.garnix.io` now answers **502** for every narinfo request.

It sat *ahead* of `cache.nixos.org` in the substituter list, so every store
path was queried there first — each one costing a failed request before
falling back. And a `nix develop` in an unrelated repo failed outright rather
than degrading: a substituter **erroring** is not the same to nix as a
substituter **missing** a path.

Removed in four places:

- `modules/base/default.nix` — the shared settings that generate
  `/etc/nix/nix.conf` on every host
- `flake-modules/ami-images.nix`
- `flake-modules/hosts/installer-iso/default.nix`
- `flake-modules/hosts/download-server-1/default.nix` — its allowed-domain
  list, which would otherwise keep permitting egress to a host that no longer
  exists

Its `trusted-public-keys` entry goes with it. A key for a cache that is not in
the substituter list does nothing, and leaving it behind would let a future
re-add of the URL silently trust a domain someone else may now control.

## Verification

`nixosConfigurations.ali-desktop.config.nix.settings.substituters` evaluates
and no longer contains it.

**Not applied.** This needs a `nixos-rebuild switch` on each host, which is a
live change — including the pharos CI runner, whose builds hit the same 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3Htn9kv5sxT7niAdqt4Bn