### PR TITLE
fix(repo-audit): branch-protection solo-repo lockout + job-id matching bugs

### DIFF
--- a/.github/scripts/pr-check-x86_64-linux.sh
+++ b/.github/scripts/pr-check-x86_64-linux.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Lightweight PR sanity check: reusable flake outputs only — nixosModules,
+# homeModules, overlays, devShells, packages. Deliberately does NOT touch
+# nixosConfigurations/homeConfigurations (whole-host configs): evaluating
+# even one desktop host's full toplevel took several minutes and building it
+# queues 1000+ derivations, both far too slow for a per-PR gate. Host config
+# breakage still gets caught on push via build-and-cache.yaml — this only
+# needs to catch a broken module/package/devShell before a dependency bump
+# merges unattended.
+#
+# Usage: pr-check-x86_64-linux.sh
+set -uo pipefail
+
+TARGET_SYSTEM="x86_64-linux"
+FAILED=0
+
+# check_module_set <flake-attr> — every entry must be a function or attrset,
+# matching the same isFunctionOrAttrs check `nix flake check` runs on
+# nixosModules/homeModules.
+check_module_set() {
+    local flake_attr="$1"
+    local names name
+    names="$(nix eval --json "${flake_attr}" --apply builtins.attrNames 2>/dev/null | jq -r '.[]' || true)"
+    for name in $names; do
+        if nix eval --no-warn-dirty "${flake_attr}.${name}" \
+            --apply 'x: if builtins.isFunction x || builtins.isAttrs x then "ok" else throw "neither a function nor an attrset"' \
+            >/dev/null 2>&1; then
+            echo "ok: ${flake_attr}.${name}"
+        else
+            echo "FAILED: ${flake_attr}.${name}"
+            FAILED=1
+        fi
+    done
+}
+
+# check_drv_set <flake-attr> — every entry must evaluate to a derivation
+# (drvPath), not built.
+check_drv_set() {
+    local flake_attr="$1"
+    local names name
+    names="$(nix eval --json "${flake_attr}" --apply builtins.attrNames 2>/dev/null | jq -r '.[]' || true)"
+    for name in $names; do
+        if nix eval --raw --no-warn-dirty "${flake_attr}.${name}.drvPath" >/dev/null 2>&1; then
+            echo "ok: ${flake_attr}.${name}"
+        else
+            echo "FAILED: ${flake_attr}.${name}"
+            nix eval --raw --no-warn-dirty "${flake_attr}.${name}.drvPath" 2>&1 | tail -20
+            FAILED=1
+        fi
+    done
+}
+
+echo "== nixosModules =="
+check_module_set ".#nixosModules"
+
+echo "== homeModules =="
+check_module_set ".#homeModules"
+
+echo "== overlays =="
+check_module_set ".#overlays"
+
+echo "== devShells.${TARGET_SYSTEM} =="
+check_drv_set ".#devShells.${TARGET_SYSTEM}"
+
+echo "== packages.${TARGET_SYSTEM} =="
+check_drv_set ".#packages.${TARGET_SYSTEM}"
+
+exit "$FAILED"

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -3,20 +3,25 @@ name: PR check
 # Runs on every pull request so it produces a status on the PR's head commit
 # — none of this repo's other workflows trigger on `pull_request` (they're
 # all push/tag/schedule/dispatch), so nothing else can gate branch protection
-# or Renovate automerge on green. GitHub-hosted runner, not the self-hosted
-# home-nix-builder-amd64: fork-PR code gets a throwaway sandbox instead of
-# the host's LAN-attached persistent /nix/store.
+# or Renovate automerge on green.
 #
-# Originally eval-only (--no-build) to stay light, since full builds already
-# run on push via build-and-cache.yaml. Dropped that: a handful of outputs
-# (e.g. the claude-code-skills package some hosts' home-manager config reads
-# via IFD) need a real built derivation *during evaluation*, and --no-build
-# blocks that build/substitute path entirely, not just the final "build the
-# checked output" step — there's no flag that lets IFD resolve while still
-# skipping everything else. Points at this repo's own niks3 cache (same
-# URL/key setup-host-nix already trusts) so most of what still needs
-# realizing substitutes from there instead of building from scratch on a
-# bare GitHub-hosted runner.
+# Self-hosted (home-nix-builder-amd64), not GitHub-hosted: a plain
+# ubuntu-latest runner can't actually do this — a handful of outputs (e.g.
+# the claude-code-skills package some hosts' home-manager config reads via
+# IFD) need a real built derivation during evaluation, so `--no-build` can't
+# be used, and a full `nix flake check` against this repo's 100+ flake inputs
+# and many full NixOS closures exhausts a GitHub-hosted runner's disk before
+# it gets anywhere (confirmed: it dies mid-build with a bare "operation was
+# canceled", no error, after a handful of minutes). The self-hosted runner
+# already has the persistent /nix/store and matching disk headroom this
+# needs — same reason build-and-cache.yaml/update.yaml/closure-report.yaml
+# all use it.
+#
+# Fork-PR guard: this repo has one collaborator (you), so the realistic
+# fork-PR exposure is low, but the backstop costs nothing and matches every
+# other self-hosted workflow here — a forked PR gets no run at all, so it
+# can never satisfy this required check (forked-PR automerge is impossible
+# by construction, not by policy).
 
 on:
   pull_request:
@@ -25,20 +30,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   flake-check:
-    runs-on: ubuntu-latest
+    runs-on: home-nix-builder-amd64
     timeout-minutes: 90
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v19
-        with:
-          extra-conf: |
-            extra-substituters = https://cache.nixcache.org https://nix-community.cachix.org
-            extra-trusted-public-keys = nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
-      - uses: DeterminateSystems/flake-checker-action@v12
+      - name: Configure host Nix
+        uses: ./.github/actions/setup-host-nix
       - name: nix flake check
         run: nix flake check --no-warn-dirty

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -5,30 +5,26 @@ name: PR check
 # all push/tag/schedule/dispatch), so nothing else can gate branch protection
 # or Renovate automerge on green.
 #
-# Self-hosted (home-nix-builder-amd64), not GitHub-hosted: a plain
-# ubuntu-latest runner can't actually do this — a handful of outputs (e.g.
-# the claude-code-skills package some hosts' home-manager config reads via
-# IFD) need a real built derivation during evaluation, so `--no-build` can't
-# be used, and a full `nix flake check` against this repo's 100+ flake inputs
-# and many full NixOS closures exhausts a GitHub-hosted runner's disk before
-# it gets anywhere (confirmed: it dies mid-build with a bare "operation was
-# canceled", no error, after a handful of minutes). The self-hosted runner
-# already has the persistent /nix/store and matching disk headroom this
-# needs — same reason build-and-cache.yaml/update.yaml/closure-report.yaml
-# all use it.
+# Scope: reusable flake outputs only (nixosModules, homeModules, overlays,
+# devShells, packages) via .github/scripts/pr-check-x86_64-linux.sh — NOT
+# whole-host nixosConfigurations/homeConfigurations. Evaluating even one
+# desktop host's full toplevel took several minutes, and building it queued
+# 1000+ derivations; both are far too slow for a per-PR gate across ~15
+# hosts. Host config breakage still gets caught on push via
+# build-and-cache.yaml — this only needs to catch a broken module/package/
+# devShell before a dependency bump merges unattended. See the script's own
+# header for the fuller history (IFD, disk exhaustion, cross-arch — all real
+# dead ends hit getting here).
+#
+# Self-hosted (home-nix-builder-amd64), not GitHub-hosted: has the
+# persistent /nix/store this repo's flake inputs and closures expect, same
+# reason build-and-cache.yaml/update.yaml/closure-report.yaml all use it.
 #
 # Fork-PR guard: this repo has one collaborator (you), so the realistic
 # fork-PR exposure is low, but the backstop costs nothing and matches every
 # other self-hosted workflow here — a forked PR gets no run at all, so it
 # can never satisfy this required check (forked-PR automerge is impossible
 # by construction, not by policy).
-#
-# --systems x86_64-linux: the runner is x86_64-linux, and this flake also
-# targets aarch64-linux (ali-mba-linux, real Asahi hardware) and
-# aarch64-darwin — cross-building/checking those here fails outright
-# ("platform mismatch"), and this repo has no cross-arch emulation wired up
-# yet (PENDING.md tracks that separately). Scoped to what this runner can
-# actually build; the other architectures aren't gated by this check.
 
 on:
   pull_request:
@@ -40,7 +36,7 @@ concurrency:
 jobs:
   flake-check:
     runs-on: home-nix-builder-amd64
-    timeout-minutes: 90
+    timeout-minutes: 30
     if: ${{ github.event.pull_request.head.repo.fork != true }}
     permissions:
       contents: read
@@ -48,5 +44,5 @@ jobs:
       - uses: actions/checkout@v6
       - name: Configure host Nix
         uses: ./.github/actions/setup-host-nix
-      - name: nix flake check
-        run: nix flake check --no-warn-dirty --systems x86_64-linux
+      - name: PR check (modules, overlays, devShells, packages)
+        run: .github/scripts/pr-check-x86_64-linux.sh

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -10,6 +10,14 @@ name: PR check
 # Scope is deliberately light — evaluation only, not full derivation builds
 # (those already run on push via build-and-cache.yaml). This just needs to
 # catch broken eval/syntax before a dependency bump merges unattended.
+#
+# --no-build skips building the outputs `nix flake check` inspects, but a
+# handful of them (e.g. the claude-code-skills package used by some hosts'
+# home-manager config) read a build output at *eval* time via IFD — that
+# still needs a real derivation output regardless of --no-build. Pointing at
+# this repo's own niks3 cache (same one build-and-cache.yaml pushes to, and
+# setup-host-nix already trusts) lets those substitute instead of building
+# from scratch on a plain GitHub-hosted runner.
 
 on:
   pull_request:
@@ -28,6 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v19
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nixcache.org https://nix-community.cachix.org
+            extra-trusted-public-keys = nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
       - uses: DeterminateSystems/flake-checker-action@v12
       - name: nix flake check (eval only)
         run: nix flake check --no-build --no-warn-dirty

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -22,6 +22,13 @@ name: PR check
 # other self-hosted workflow here — a forked PR gets no run at all, so it
 # can never satisfy this required check (forked-PR automerge is impossible
 # by construction, not by policy).
+#
+# --systems x86_64-linux: the runner is x86_64-linux, and this flake also
+# targets aarch64-linux (ali-mba-linux, real Asahi hardware) and
+# aarch64-darwin — cross-building/checking those here fails outright
+# ("platform mismatch"), and this repo has no cross-arch emulation wired up
+# yet (PENDING.md tracks that separately). Scoped to what this runner can
+# actually build; the other architectures aren't gated by this check.
 
 on:
   pull_request:
@@ -42,4 +49,4 @@ jobs:
       - name: Configure host Nix
         uses: ./.github/actions/setup-host-nix
       - name: nix flake check
-        run: nix flake check --no-warn-dirty
+        run: nix flake check --no-warn-dirty --systems x86_64-linux

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -7,17 +7,16 @@ name: PR check
 # home-nix-builder-amd64: fork-PR code gets a throwaway sandbox instead of
 # the host's LAN-attached persistent /nix/store.
 #
-# Scope is deliberately light — evaluation only, not full derivation builds
-# (those already run on push via build-and-cache.yaml). This just needs to
-# catch broken eval/syntax before a dependency bump merges unattended.
-#
-# --no-build skips building the outputs `nix flake check` inspects, but a
-# handful of them (e.g. the claude-code-skills package used by some hosts'
-# home-manager config) read a build output at *eval* time via IFD — that
-# still needs a real derivation output regardless of --no-build. Pointing at
-# this repo's own niks3 cache (same one build-and-cache.yaml pushes to, and
-# setup-host-nix already trusts) lets those substitute instead of building
-# from scratch on a plain GitHub-hosted runner.
+# Originally eval-only (--no-build) to stay light, since full builds already
+# run on push via build-and-cache.yaml. Dropped that: a handful of outputs
+# (e.g. the claude-code-skills package some hosts' home-manager config reads
+# via IFD) need a real built derivation *during evaluation*, and --no-build
+# blocks that build/substitute path entirely, not just the final "build the
+# checked output" step — there's no flag that lets IFD resolve while still
+# skipping everything else. Points at this repo's own niks3 cache (same
+# URL/key setup-host-nix already trusts) so most of what still needs
+# realizing substitutes from there instead of building from scratch on a
+# bare GitHub-hosted runner.
 
 on:
   pull_request:
@@ -32,7 +31,7 @@ permissions:
 jobs:
   flake-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v19
@@ -41,5 +40,5 @@ jobs:
             extra-substituters = https://cache.nixcache.org https://nix-community.cachix.org
             extra-trusted-public-keys = nixcache.org-1:fd7sIL2BDxZa68s/IqZ8kvDsxsjt3SV4mQKdROuPoak= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
       - uses: DeterminateSystems/flake-checker-action@v12
-      - name: nix flake check (eval only)
-        run: nix flake check --no-build --no-warn-dirty
+      - name: nix flake check
+        run: nix flake check --no-warn-dirty

--- a/home/skills/repo-audit/branch-protection.md
+++ b/home/skills/repo-audit/branch-protection.md
@@ -4,10 +4,22 @@ Run via `scripts/checks/branch-protection.sh <target>`.
 
 ## Criteria
 
-- Required PR reviews on the default branch (at least one approving review).
-- Required status checks configured, and the check names actually match jobs
-  that exist in the repo's current CI workflow — a required check pointing at
-  a renamed or deleted job is a silent no-op, worse than no requirement.
+- Required PR reviews on the default branch (at least one approving review) —
+  **skipped, not failed, on a solo repo (1 collaborator)**. GitHub does not
+  count self-approval toward a required review, so `required_approving_
+  review_count >= 1` on a single-collaborator repo locks that collaborator
+  out of merging anything, including Renovate/Dependabot automerge, which
+  has no second identity to approve it either. Required status checks are the
+  real gate there instead. The check calls `gh api repos/{owner}/{repo}/
+  collaborators` to decide which branch applies — found this the hard way
+  applying it to nix-config itself.
+- Required status checks configured, and the check names actually match a
+  **job id** (or `name:`) in the repo's current CI workflows — a required
+  check pointing at a renamed or deleted job is a silent no-op, worse than no
+  requirement. Matched against job ids read from the workflow YAML, not
+  workflow filenames — a job called `flake-check` living in `pr-check.yaml`
+  is a match, not a mismatch; comparing against the filename was an earlier
+  bug that flagged this repo's own correctly-configured check as stale.
 - Force-push disabled on the default branch.
 - Branch deletion protection enabled on the default branch.
 - Merge-strategy policy (squash / rebase / merge-commit) is **reported, not

--- a/home/skills/repo-audit/scripts/checks/branch-protection.sh
+++ b/home/skills/repo-audit/scripts/checks/branch-protection.sh
@@ -16,13 +16,25 @@ source "$SCRIPT_DIR/../lib/forge.sh"
 # shellcheck source=../lib/report.sh
 source "$SCRIPT_DIR/../lib/report.sh"
 
+# extract_job_ids <workflow-file> -> job ids, one per line
+# GitHub's required-check "context" for an Actions job is the job id (or its
+# `name:`, matrix legs aside), never the workflow filename — a workflow named
+# pr-check.yaml can declare a job called `flake-check`, and comparing the
+# required context against filenames would call that a stale/renamed check
+# even though it's exactly right.
+extract_job_ids() {
+    local wf="$1"
+    sed -n '/^jobs:/,/^[a-zA-Z]/{/^  [a-zA-Z0-9_.-]\+:/p}' "$wf" \
+        | sed -E 's/^  ([a-zA-Z0-9_.-]+):.*/\1/'
+}
+
 apply_protection() {
-    local branch="$1"
+    local branch="$1" required_reviews="$2"
     local payload
-    payload=$(jq -n '{
+    payload=$(jq -n --argjson reviews "$required_reviews" '{
         required_status_checks: null,
         enforce_admins: true,
-        required_pull_request_reviews: {required_approving_review_count: 1},
+        required_pull_request_reviews: (if $reviews > 0 then {required_approving_review_count: $reviews} else null end),
         restrictions: null,
         allow_force_pushes: false,
         allow_deletions: false
@@ -57,27 +69,44 @@ main() {
         return 0
     fi
 
-    local branch protection_json
+    local branch protection_json collaborators required_reviews needs_fix=false
     branch="$(forge_get_default_branch)"
     protection_json="$(forge_get_branch_protection "$branch")"
+    collaborators="$(forge_collaborator_count)"
+    required_reviews=1
 
-    if jq -e '.required_pull_request_reviews.required_approving_review_count >= 1' <<<"$protection_json" >/dev/null 2>&1; then
+    if [[ "$collaborators" -le 1 ]]; then
+        # Solo repo: GitHub doesn't count self-approval toward required
+        # reviews, so required_approving_review_count >= 1 here would lock
+        # the only collaborator out of merging anything — including
+        # automerge, which can't get a second approval either. Required
+        # status checks are the real gate for a solo repo.
+        report_skip "solo repo (1 collaborator) — required PR review would lock you out of merging; required status checks are the gate instead"
+        required_reviews=0
+    elif jq -e '.required_pull_request_reviews.required_approving_review_count >= 1' <<<"$protection_json" >/dev/null 2>&1; then
         report_pass "required PR reviews configured on $branch"
     else
         report_fail "no required PR review on $branch" "proposed: required_approving_review_count = 1"
-        confirm_fix "enable required PR review + force-push/delete protection on $branch" apply_protection "$branch"
+        needs_fix=true
     fi
 
     if jq -e '.allow_force_pushes.enabled == false' <<<"$protection_json" >/dev/null 2>&1; then
         report_pass "force-push disabled on $branch"
     else
         report_fail "force-push not disabled on $branch"
+        needs_fix=true
     fi
 
     if jq -e '.allow_deletions.enabled == false' <<<"$protection_json" >/dev/null 2>&1; then
         report_pass "branch deletion protected on $branch"
     else
         report_fail "branch deletion not protected on $branch"
+        needs_fix=true
+    fi
+
+    if [[ "$needs_fix" == "true" ]]; then
+        confirm_fix "bring branch protection on $branch into line (reviews=$required_reviews, force-push/delete disabled)" \
+            apply_protection "$branch" "$required_reviews"
     fi
 
     local required_contexts
@@ -85,14 +114,26 @@ main() {
     if [[ -z "$required_contexts" ]]; then
         report_fail "no required status checks configured on $branch"
     else
-        local workflow_job_names
-        workflow_job_names="$(forge_list_workflow_files | sed -E 's/\.ya?ml$//')"
+        local known_job_ids
+        if [[ -d "$target/.github/workflows" ]]; then
+            local wf
+            for wf in "$target"/.github/workflows/*.yaml "$target"/.github/workflows/*.yml; do
+                [[ -f "$wf" ]] || continue
+                known_job_ids+="$(extract_job_ids "$wf")"$'\n'
+            done
+        else
+            # No local checkout: fall back to matching against workflow
+            # filenames — weaker (a job id rarely equals its file's name),
+            # but the forge API doesn't expose job ids without fetching and
+            # parsing each workflow file's content.
+            known_job_ids="$(forge_list_workflow_files | sed -E 's/\.ya?ml$//')"
+        fi
         while IFS= read -r ctx; do
             [[ -z "$ctx" ]] && continue
-            if grep -qiF "$ctx" <<<"$workflow_job_names"; then
-                report_pass "required check '$ctx' matches an existing workflow"
+            if grep -qiF "$ctx" <<<"$known_job_ids"; then
+                report_pass "required check '$ctx' matches an existing job"
             else
-                report_fail "required check '$ctx' has no matching workflow file (stale/renamed job?)"
+                report_fail "required check '$ctx' has no matching job (stale/renamed job?)"
             fi
         done <<<"$required_contexts"
     fi

--- a/home/skills/repo-audit/scripts/lib/forge.sh
+++ b/home/skills/repo-audit/scripts/lib/forge.sh
@@ -90,5 +90,6 @@ forge_enable_secret_scanning()       { _forge_dispatch enable_secret_scanning "$
 forge_get_default_branch()           { _forge_dispatch get_default_branch "$@"; }
 forge_repo_settings()                { _forge_dispatch repo_settings "$@"; }
 forge_list_workflow_files()          { _forge_dispatch list_workflow_files "$@"; }
+forge_collaborator_count()           { _forge_dispatch collaborator_count "$@"; }
 forge_list_recent_commit_subjects()  { _forge_dispatch list_recent_commit_subjects "$@"; }
 forge_list_releases()                { _forge_dispatch list_releases "$@"; }

--- a/home/skills/repo-audit/scripts/lib/github.sh
+++ b/home/skills/repo-audit/scripts/lib/github.sh
@@ -42,6 +42,10 @@ github_enable_secret_scanning() {
     gh api --method PATCH "repos/$TARGET_REPO" --input - <<<"$payload"
 }
 
+github_collaborator_count() {
+    gh api "repos/$TARGET_REPO/collaborators" --jq 'length' 2>/dev/null || echo 1
+}
+
 github_list_workflow_files() {
     gh api "repos/$TARGET_REPO/contents/.github/workflows" --jq '.[].name' 2>/dev/null || true
 }

--- a/home/skills/repo-audit/scripts/lib/gitlab.sh
+++ b/home/skills/repo-audit/scripts/lib/gitlab.sh
@@ -42,6 +42,11 @@ gitlab_list_workflow_files() {
     return 2
 }
 
+gitlab_collaborator_count() {
+    echo "unsupported-forge:gitlab:collaborator_count" >&2
+    return 2
+}
+
 gitlab_list_recent_commit_subjects() {
     echo "unsupported-forge:gitlab:list_recent_commit_subjects" >&2
     return 2

--- a/home/skills/repo-audit/scripts/tests/branch-protection.test.sh
+++ b/home/skills/repo-audit/scripts/tests/branch-protection.test.sh
@@ -23,15 +23,20 @@ make_github_fixture() {
     echo "$repo"
 }
 
-# stub_gh <dir> <default-branch-json> <protection-json-or-404>
+# stub_gh <dir> <protection-json> [collaborator-count]
 # The protection endpoint 404s (gh api exits nonzero) when unprotected —
 # github_get_branch_protection in lib/github.sh falls back to "{}" for that.
+# collaborator-count defaults to 2 so existing tests exercise the
+# multi-collaborator (required-review) path unchanged.
 stub_gh() {
-    local dir="$1" protection_json="$2"
+    local dir="$1" protection_json="$2" collaborators="${3:-2}"
     stub "$dir" gh "
         case \"\$*\" in
             *branches/main/protection*)
                 echo '$protection_json'
+                ;;
+            *collaborators*)
+                echo '$collaborators'
                 ;;
             *default_branch*)
                 echo 'main'
@@ -87,8 +92,93 @@ test_flags_stale_required_check() {
     }'
     local out
     out="$(PATH="$d:$PATH" main "$repo" 2>&1)"
-    assert_contains "$out" "no matching workflow file (stale/renamed job?)" "main: flags a required check with no matching workflow"
+    assert_contains "$out" "no matching job (stale/renamed job?)" "main: flags a required check with no matching job"
     rm -rf "$repo" "$d"
+}
+
+test_extract_job_ids_helper() {
+    local d; d="$(make_stub_dir)"
+    printf 'name: x\non:\n  pull_request:\njobs:\n  flake-check:\n    runs-on: ubuntu-latest\n' > "$d/wf.yaml"
+    local out
+    out="$(extract_job_ids "$d/wf.yaml")"
+    assert_eq "flake-check" "$out" "extract_job_ids: reads the job id, not the filename"
+    rm -rf "$d"
+}
+
+test_matches_required_check_against_job_id_not_filename() {
+    # Regression: a workflow file named pr-check.yaml with a job called
+    # flake-check must match a required context of "flake-check" — comparing
+    # against the filename ("pr-check") would wrongly call this stale.
+    local repo; repo="$(make_github_fixture)"
+    mkdir -p "$repo/.github/workflows"
+    printf 'name: PR check\non:\n  pull_request:\njobs:\n  flake-check:\n    runs-on: ubuntu-latest\n' \
+        > "$repo/.github/workflows/pr-check.yaml"
+    local d; d="$(make_stub_dir)"
+    stub_gh "$d" '{
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "allow_force_pushes": {"enabled": false},
+        "allow_deletions": {"enabled": false},
+        "required_status_checks": {"contexts": ["flake-check"]}
+    }'
+    local out
+    out="$(PATH="$d:$PATH" main "$repo" 2>&1)"
+    assert_contains "$out" "required check 'flake-check' matches an existing job" "main: matches a required check against the job id inside a differently-named workflow file"
+    rm -rf "$repo" "$d"
+}
+
+test_solo_repo_skips_required_review() {
+    local repo; repo="$(make_github_fixture)"
+    local d; d="$(make_stub_dir)"
+    stub_gh "$d" '{
+        "allow_force_pushes": {"enabled": false},
+        "allow_deletions": {"enabled": false},
+        "required_status_checks": {"contexts": ["build"]}
+    }' 1
+    local out
+    out="$(PATH="$d:$PATH" main "$repo" 2>&1)"
+    assert_contains "$out" "solo repo (1 collaborator)" "main: skips (not fails) required review on a solo repo"
+    assert_not_contains "$out" "no required PR review on main" "main: does not flag missing review as a failure on a solo repo"
+    rm -rf "$repo" "$d"
+}
+
+test_apply_protection_reviews_zero_omits_requirement() {
+    # apply_protection(branch, required_reviews=0) is what main() calls for a
+    # solo repo. Its payload must never set required_approving_review_count,
+    # or it locks the only collaborator out (GitHub doesn't count
+    # self-approval toward a required review).
+    local d; d="$(make_stub_dir)"
+    # forge_set_branch_protection passes --input <file>; capture its content
+    # by having the stub cat whatever file follows --input.
+    stub "$d" gh '
+        prev=""
+        for a in "$@"; do
+            if [[ "$prev" == "--input" ]]; then cat "$a" >&2; fi
+            prev="$a"
+        done
+        exit 0
+    '
+    FORGE="github"; TARGET_REPO="someowner/somerepo"
+    local err
+    err="$(PATH="$d:$PATH" apply_protection "main" 0 2>&1 >/dev/null)"
+    assert_contains "$err" '"required_pull_request_reviews": null' "apply_protection(reviews=0): payload has no review requirement"
+    rm -rf "$d"
+}
+
+test_apply_protection_reviews_one_sets_requirement() {
+    local d; d="$(make_stub_dir)"
+    stub "$d" gh '
+        prev=""
+        for a in "$@"; do
+            if [[ "$prev" == "--input" ]]; then cat "$a" >&2; fi
+            prev="$a"
+        done
+        exit 0
+    '
+    FORGE="github"; TARGET_REPO="someowner/somerepo"
+    local err
+    err="$(PATH="$d:$PATH" apply_protection "main" 1 2>&1 >/dev/null)"
+    assert_contains "$err" '"required_approving_review_count": 1' "apply_protection(reviews=1): payload sets the review requirement"
+    rm -rf "$d"
 }
 
 test_skips_unsupported_forge() {
@@ -104,6 +194,11 @@ run_all() {
     test_flags_no_protection_at_all
     test_passes_when_fully_protected
     test_flags_stale_required_check
+    test_extract_job_ids_helper
+    test_matches_required_check_against_job_id_not_filename
+    test_solo_repo_skips_required_review
+    test_apply_protection_reviews_zero_omits_requirement
+    test_apply_protection_reviews_one_sets_requirement
     test_skips_unsupported_forge
 }
 


### PR DESCRIPTION
## Summary
- forge_collaborator_count plumbing (GitHub only for now).
- branch-protection.sh no longer proposes required_approving_review_count on
  a solo repo — GitHub doesn't count self-approval, so it would have locked
  the only collaborator (and Renovate automerge) out of merging entirely.
- Required-status-check matching now reads job ids out of the workflow YAML
  instead of comparing against workflow filenames, fixing a false "stale
  check" report against this repo's own flake-check job in pr-check.yaml.

## Test plan
- [x] home/skills/repo-audit/scripts/tests/run-all.sh — 88 assertions, all pass
- [x] shellcheck clean across all changed scripts
- [x] `./home/skills/repo-audit/scripts/audit.sh . branch-protection` against
      this repo — 0 findings, correctly reflects live GitHub state