### PR TITLE
fix(ali-desktop): restore libGL.so.1 for Steam gamescope launches

### DIFF
--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -32,6 +32,7 @@ in {
       # set — but only if the module is in the list at all.
       self.nixosModules.desktop-wm-plasma6
       self.nixosModules.audio-context-suspend
+      self.nixosModules.audio-usb-reconnect-heal
       self.nixosModules.base
       self.nixosModules.camera-resume
       self.nixosModules.desktop
@@ -373,6 +374,49 @@ in {
         services.audio-context-suspend = {
           enable = true;
           user = "ali";
+        };
+
+        # Fixes the incident from 2026-08-19: the Scarlett sits behind a USB
+        # switch and briefly dropped mid-session, which left two PipeWire
+        # links missing -- EasyEffects' virtual sink never reached the
+        # Scarlett's hardware playback ports, and the binaural spatializer
+        # never reached EasyEffects. Everything downstream still looked
+        # healthy (unmuted, RUNNING, hw_ptr advancing); only those specific
+        # links were gone, and nothing recreates them on its own.
+        #
+        # Deliberately relinks rather than restarting wireplumber: doing the
+        # latter live-drops every active PipeWire stream, which is how a
+        # Zoom call's mic got killed mid-session while chasing this same bug.
+        services.audio-usb-reconnect-heal = {
+          enable = true;
+          user = "ali";
+          devices = [
+            {
+              name = "Focusrite Scarlett 2i2 4th Gen";
+              vendorId = "1235";
+              productId = "8219";
+            }
+          ];
+          expectedLinks = let
+            scarlettOut = "alsa_output.usb-Focusrite_Scarlett_2i2_4th_Gen_S2R68MK3712AC3-00.pro-output-0";
+          in [
+            {
+              output = "easyeffects_sink:monitor_FL";
+              input = "${scarlettOut}:playback_FL";
+            }
+            {
+              output = "easyeffects_sink:monitor_FR";
+              input = "${scarlettOut}:playback_FR";
+            }
+            {
+              output = "effect_output.binaural71:output_FL";
+              input = "easyeffects_sink:playback_FL";
+            }
+            {
+              output = "effect_output.binaural71:output_FR";
+              input = "easyeffects_sink:playback_FR";
+            }
+          ];
         };
 
         # S3 drops VBUS to the root hubs, so the OBSBOT re-enumerates on every

--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -599,6 +599,21 @@ in {
           # once unstable catches up to 26.x.
           graphics.package = lib.mkForce pkgs.master.mesa;
           graphics.package32 = lib.mkForce pkgs.master.pkgsi686Linux.mesa;
+
+          # Modern mesa (both nixos-unstable 26.1.5 and master 26.2.0 —
+          # checked both directly) is GLVND-only: it ships libGLX_mesa.so
+          # / libEGL_mesa.so ICDs but never libGL.so.1 itself. The NixOS
+          # `hardware.graphics` module doesn't add libglvnd on its own
+          # either (checked nixos/modules/hardware/graphics.nix — no
+          # glvnd handling at all), so without an explicit extraPackages
+          # entry /run/opengl-driver never gets a libGL.so.1 dispatcher.
+          # Surfaced when the gamescope launch chain's LD_PRELOAD'd
+          # overlay/mangohud layer needs it and gamemoderun's bash dies
+          # with "error while loading shared libraries: libGL.so.1".
+          # Pull libglvnd from the same pkgs.master used above so its
+          # ABI matches the mesa ICDs it's dispatching to.
+          graphics.extraPackages = [ pkgs.master.libglvnd ];
+          graphics.extraPackages32 = [ pkgs.master.pkgsi686Linux.libglvnd ];
         };
 
         # Disable NetworkManager-wait-online — desktop doesn't need network up before login

--- a/flake-modules/nixos-modules.nix
+++ b/flake-modules/nixos-modules.nix
@@ -2,6 +2,7 @@
   flake.nixosModules = {
     # Core modules
     audio-context-suspend = import ../modules/audio-context-suspend.nix;
+    audio-usb-reconnect-heal = import ../modules/audio-usb-reconnect-heal.nix;
     aws = import ../modules/aws;
     base = import ../modules/base;
     camera-resume = import ../modules/camera-resume.nix;

--- a/modules/audio-usb-reconnect-heal.nix
+++ b/modules/audio-usb-reconnect-heal.nix
@@ -8,7 +8,7 @@ with lib; let
   cfg = config.services.audio-usb-reconnect-heal;
 
   # Root, because udev rules run as root; pw-link needs the user's PipeWire.
-  asUser = "${pkgs.util-linux}/bin/runuser -u ${cfg.user} --";
+  asUser = "${pkgs.util-linux}/bin/runuser -u ${lib.escapeShellArg cfg.user} --";
 
   udevRules =
     concatMapStringsSep "\n" (d: ''
@@ -16,7 +16,9 @@ with lib; let
     '')
     cfg.devices;
 
-  # Shell-quoted "output-port input-port" pairs, fed to the relink loop below.
+  # Space-delimited "output-port input-port" pairs, one per line, fed to the
+  # relink loop's `read -r out_port in_port` below. Not shell-quoted -- relies
+  # on port names (Nix-generated node:port strings) never containing spaces.
   linkList = concatMapStringsSep "\n" (l: "${l.output} ${l.input}") cfg.expectedLinks;
 in {
   options.services.audio-usb-reconnect-heal = {
@@ -64,7 +66,7 @@ in {
         options = {
           name = mkOption {
             type = types.str;
-            description = "Human-readable name, used only in log lines.";
+            description = "Human-readable name, for readability in the config only -- not referenced at runtime.";
           };
           vendorId = mkOption {
             type = types.strMatching "[0-9a-f]{4}";

--- a/modules/audio-usb-reconnect-heal.nix
+++ b/modules/audio-usb-reconnect-heal.nix
@@ -1,0 +1,155 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.audio-usb-reconnect-heal;
+
+  # Root, because udev rules run as root; pw-link needs the user's PipeWire.
+  asUser = "${pkgs.util-linux}/bin/runuser -u ${cfg.user} --";
+
+  udevRules =
+    concatMapStringsSep "\n" (d: ''
+      SUBSYSTEM=="usb", ATTR{idVendor}=="${d.vendorId}", ATTR{idProduct}=="${d.productId}", ENV{DEVTYPE}=="usb_device", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}+="audio-usb-reconnect-heal.service"
+    '')
+    cfg.devices;
+
+  # Shell-quoted "output-port input-port" pairs, fed to the relink loop below.
+  linkList = concatMapStringsSep "\n" (l: "${l.output} ${l.input}") cfg.expectedLinks;
+in {
+  options.services.audio-usb-reconnect-heal = {
+    enable = mkEnableOption ''
+      Self-heal specific PipeWire port links after a tracked USB audio
+      device reconnects.
+
+      A USB audio interface that drops and comes back mid-session (e.g.
+      behind a USB switch) can leave WirePlumber unable to re-establish
+      some of the graph's links -- seen on ali-desktop as the Focusrite
+      Scarlett briefly failing to open its ALSA control device, after
+      which the link from EasyEffects' virtual sink to the Scarlett's
+      hardware playback ports (and from the binaural spatializer into
+      EasyEffects) silently never got remade. Everything downstream
+      still looked healthy -- unmuted, RUNNING, hw_ptr advancing -- only
+      the specific port link was missing, and PipeWire has no facility
+      to reassert it on its own.
+
+      This recreates only the named links, with `pw-link`, which is a
+      no-op if a link already exists. It deliberately does NOT restart
+      wireplumber or any client: that tears down every live PipeWire
+      stream, including an in-progress call's audio -- confirmed the
+      hard way on 2026-08-19, when restarting wireplumber to fix this
+      exact symptom killed a live Zoom call's mic stream mid-session.
+    '';
+
+    user = mkOption {
+      type = types.str;
+      description = "User whose PipeWire session to heal.";
+    };
+
+    devices = mkOption {
+      description = "USB audio devices to watch for reconnect-induced link loss.";
+      default = [];
+      example = literalExpression ''
+        [
+          {
+            name = "Focusrite Scarlett 2i2 4th Gen";
+            vendorId = "1235";
+            productId = "8219";
+          }
+        ]
+      '';
+      type = types.listOf (types.submodule {
+        options = {
+          name = mkOption {
+            type = types.str;
+            description = "Human-readable name, used only in log lines.";
+          };
+          vendorId = mkOption {
+            type = types.strMatching "[0-9a-f]{4}";
+            description = "USB idVendor, lowercase hex, as printed by lsusb.";
+          };
+          productId = mkOption {
+            type = types.strMatching "[0-9a-f]{4}";
+            description = "USB idProduct, lowercase hex, as printed by lsusb.";
+          };
+        };
+      });
+    };
+
+    expectedLinks = mkOption {
+      description = ''
+        PipeWire port links that must exist for audio to reach hardware,
+        given as fully-qualified `node:port` pairs (as printed by
+        `pw-link -l`). Recreated whenever a tracked device reconnects.
+      '';
+      default = [];
+      example = literalExpression ''
+        [
+          {
+            output = "easyeffects_sink:monitor_FL";
+            input = "alsa_output.usb-Focusrite_Scarlett_2i2_4th_Gen_..." + ":playback_FL";
+          }
+        ]
+      '';
+      type = types.listOf (types.submodule {
+        options = {
+          output = mkOption {
+            type = types.str;
+            description = "Source port, as `node:port`.";
+          };
+          input = mkOption {
+            type = types.str;
+            description = "Destination port, as `node:port`.";
+          };
+        };
+      });
+    };
+
+    settleSeconds = mkOption {
+      type = types.ints.positive;
+      default = 5;
+      description = "How long to wait after the USB add event before the ports are expected to exist.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.devices != [];
+        message = "services.audio-usb-reconnect-heal.devices must list at least one device.";
+      }
+      {
+        assertion = cfg.expectedLinks != [];
+        message = "services.audio-usb-reconnect-heal.expectedLinks must list at least one link.";
+      }
+    ];
+
+    services.udev.extraRules = mkIf (udevRules != "") udevRules;
+
+    systemd.services.audio-usb-reconnect-heal = {
+      description = "Recreate PipeWire links dropped by a tracked USB audio device reconnect";
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "audio-usb-reconnect-heal" ''
+          set -u
+          ${pkgs.coreutils}/bin/sleep ${toString cfg.settleSeconds}
+
+          # pw-link is a harmless no-op ("File exists") when the link is
+          # already there, so this only ever adds what's missing -- never
+          # tears anything down.
+          while read -r out_port in_port; do
+            [ -n "$out_port" ] || continue
+            ${asUser} ${pkgs.pipewire}/bin/pw-link "$out_port" "$in_port" >/dev/null 2>&1 \
+              && echo "audio-usb-reconnect-heal: relinked $out_port -> $in_port" \
+              || true
+          done <<'EOF'
+          ${linkList}
+          EOF
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add USB-Scarlett PipeWire link healing on reconnect (unrelated feature, bundled from the same working tree)
- Fix libGL.so.1 missing from the graphics bundle, which broke Steam gamescope game launches (surfaced via Helldivers 2 failing to start)

## Details
Root-caused via journalctl: `bash: error while loading shared libraries: libGL.so.1: cannot open shared object file`, in the gamescope→gamemoderun launch chain, before Proton ever starts.

Modern mesa (checked both nixos-unstable 26.1.5 and nixpkgs_master 26.2.0 directly) is GLVND-only — ships libGLX_mesa.so/libEGL_mesa.so but never libGL.so.1 itself. `nixos/modules/hardware/graphics.nix` doesn't add libglvnd automatically. ali-desktop overrides `hardware.graphics.package` to `pkgs.master.mesa` (for RADV gfx12 fixes) without ever pulling in libglvnd, so `/run/opengl-driver` never had a libGL.so.1 dispatcher. Not a nixpkgs regression — a pre-existing gap in this host's config that just hadn't been noticed yet.

Fix: add `pkgs.master.libglvnd` (and 32-bit) to `hardware.graphics.extraPackages{,32}`, matching the mesa build's ABI. Verified locally: built the closure and confirmed `libGL.so.1` lands in `/run/opengl-driver/lib`.

## Test plan
- [x] `nix build .#nixosConfigurations.ali-desktop.config.system.build.toplevel` succeeds
- [x] Confirmed `libGL.so.1` present in the built graphics-drivers bundle
- [x] Applied via `switch-to-configuration switch`, confirmed `/run/opengl-driver/lib/libGL.so.1` live
- [ ] Helldivers 2 launch confirmed working after a fresh Steam restart (pending — Steam was running since before the switch and had a stale env)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5zTxV5DGJRugtfTNA3sL5