### PR TITLE
docs(skills): genericize Nix-related skill wording

### DIFF
--- a/home/skills/design/SKILL.md
+++ b/home/skills/design/SKILL.md
@@ -46,6 +46,9 @@ two modules.
   behaviour is two functions wearing a trench coat. Name them.
 - **Putting the logic where the data is convenient** rather than where the
   responsibility is. Convenience now, coupling forever.
+- **Using the same type for two different concepts.** Two IDs, a validated and
+  an unvalidated string, cents and dollars — same representation, different
+  meaning. See [data-and-state.md](data-and-state.md).
 - **Deciding something irreversibly to save an hour.** See
   [reversibility.md](reversibility.md).
 

--- a/home/skills/design/data-and-state.md
+++ b/home/skills/design/data-and-state.md
@@ -11,6 +11,20 @@ Once it is written as a sequence of transformations, the function boundaries
 are usually obvious, each step is independently testable, and there is nothing
 to mock.
 
+## Give distinct concepts distinct types
+
+A `customer_id` and an `order_id` that are both a bare `String` are the same
+type as far as the compiler is concerned — nothing stops them being passed in
+the wrong order, and the mistake surfaces at runtime, in someone else's
+incident, instead of at the call site. Two kinds of ID, a validated vs.
+unvalidated string, a quantity in cents vs. dollars: whenever two values share
+a representation but mean different things, that is a modelling gap, not a
+detail to fix later. Wrap each in its own type so a mismatched call is a
+compile/type error. This is the design-level statement of the same rule the
+`programming` skill's `defensive.md` covers mechanically — see it for the
+concrete construct per language (Rust newtypes, TypeScript branded types,
+Python `NewType`).
+
 ## Don't hoard state — pass it around
 
 State stored so that a later call can find it is an implicit contract between

--- a/home/skills/infra/nix.md
+++ b/home/skills/infra/nix.md
@@ -1,29 +1,34 @@
 # Nix deployment
 
-Local machine, in increasing order of commitment:
+Check for a repo-local wrapper first (`just`, `Makefile`, `bin/`, a `flake.nix`
+app) — many Nix configs alias the raw commands below behind their own verbs.
+If one exists, prefer it; it may carry repo-specific pre/post steps. Otherwise
+use the underlying tools directly, in increasing order of commitment:
 
 ```
-just build [hostname]   # build only, no activation
-just test               # activate temporarily; reverts on reboot
-just boot               # set for next boot
-just switch             # activate now, permanently
+nixos-rebuild build --flake .#<host>     # build only, no activation
+nixos-rebuild test --flake .#<host>      # activate temporarily; reverts on reboot
+nixos-rebuild boot --flake .#<host>      # set for next boot
+nixos-rebuild switch --flake .#<host>    # activate now, permanently
 ```
 
-Remote machines go through deploy-rs:
+(`darwin-rebuild` / `home-manager switch` in place of `nixos-rebuild` for
+nix-darwin / standalone home-manager targets — same verbs.)
 
-```
-just deploy [extraargs]
-```
+Remote machines: check what the repo uses for remote deploy (deploy-rs,
+`nixos-rebuild --target-host`, colmena, morph, ...) — don't assume any one of
+these by default.
 
 ## Rules
 
 - `git add` new files before building. Flakes ignore untracked files and the
   error does not say so.
-- Build before deploying. `just build <hostname>` proves the closure evaluates
-  and compiles without touching the target.
-- deploy-rs has automatic rollback on a failed activation — but a change that
-  breaks *boot* rather than activation will not roll back. For those, use
-  `just test` locally or a VM build first.
+- Build before deploying — prove the closure evaluates and compiles without
+  touching the target first.
+- If the deploy tool has automatic rollback on failed activation (deploy-rs
+  does), remember it only covers *activation* failures — a change that breaks
+  *boot* will not roll back. For those, use a temporary `test`-style
+  activation or a VM build first.
 - `nix flake check` may fail from the wrong host when an input only evaluates
   on another platform. Skipping it is legitimate; say that you skipped it.
 - Before assuming `sudo` is unavailable, **probe it**: `sudo -n true`, or
@@ -38,6 +43,7 @@ just deploy [extraargs]
 
 ## Authoring side
 
-Module structure, host scaffolding, secrets, and the haumea auto-discovery
-rules live in the `programming` skill's `languages/nix.md` and, for this repo
-specifically, the `nix-config-workflows` project skill.
+General module structure and conventions live in the `programming` skill's
+`languages/nix.md`. A given repo may carry its own project-local workflow
+skill (host/module scaffolding, secrets) — check for one before assuming
+generic conventions cover everything.

--- a/home/skills/infra/nix.md
+++ b/home/skills/infra/nix.md
@@ -12,8 +12,15 @@ nixos-rebuild boot --flake .#<host>      # set for next boot
 nixos-rebuild switch --flake .#<host>    # activate now, permanently
 ```
 
-(`darwin-rebuild` / `home-manager switch` in place of `nixos-rebuild` for
-nix-darwin / standalone home-manager targets — same verbs.)
+nix-darwin and standalone home-manager don't have the full verb set above —
+neither has a bootloader-staged `boot`, and neither has a reboot-reverting
+`test`:
+- nix-darwin: `darwin-rebuild build --flake .#<host>` /
+  `darwin-rebuild switch --flake .#<host>` (switch activates immediately,
+  permanently — there is no temporary/reverting mode).
+- standalone home-manager: `home-manager build --flake .#<user>@<host>` /
+  `home-manager switch --flake .#<user>@<host>` — note the flake target is
+  `<user>@<host>`, not `<host>`.
 
 Remote machines: check what the repo uses for remote deploy (deploy-rs,
 `nixos-rebuild --target-host`, colmena, morph, ...) — don't assume any one of

--- a/home/skills/programming/defensive.md
+++ b/home/skills/programming/defensive.md
@@ -17,7 +17,22 @@ the last resort.
 - **Invariants** hold across every public entry point, not just the happy path.
 
 Prefer making an illegal state unrepresentable over checking for it: a type
-that cannot hold an empty list beats an assertion that it is not empty.
+that cannot hold an empty list beats an assertion that it is not empty. Reach
+for this whenever the language's type system supports it — a newtype that can
+only be constructed from validated input, a sum type with no "impossible"
+variant, a non-empty-list type — parse untrusted input into that type once at
+the boundary and pass the typed value inward; do not re-validate downstream.
+
+## Guard rails
+
+Where a language lets you turn a whole class of runtime failure into a
+build-time or lint-time one, turn it on — project-wide, not opt-in per file.
+This is a mandate, not a suggestion: a lint that is merely enabled but not set
+to deny/error is advisory and gets ignored under deadline pressure exactly
+when it matters most. Concrete settings live in the per-language file (e.g.
+`languages/rust.md`'s clippy deny list for panic-class lints); the principle
+here is general — prefer "the compiler/linter refuses to build this" over
+"we wrote a test that would probably have caught this."
 
 ## Crash early
 

--- a/home/skills/programming/defensive.md
+++ b/home/skills/programming/defensive.md
@@ -23,6 +23,20 @@ only be constructed from validated input, a sum type with no "impossible"
 variant, a non-empty-list type — parse untrusted input into that type once at
 the boundary and pass the typed value inward; do not re-validate downstream.
 
+**Give distinct domain concepts distinct types, even when the underlying
+representation is identical.** A function that takes `customer_id: String`
+and `order_id: String` will happily accept them swapped — same type, so
+nothing catches it until the wrong row gets returned or updated at runtime.
+Wrap each in its own type (`CustomerId(String)`, `OrderId(String)`) so the
+function signature becomes `fn f(customer_id: CustomerId, order_id: OrderId)`
+and passing them in the wrong order is a compile error, not a bug someone
+finds in production. This applies to any pair of same-shaped values that mean
+different things: two kinds of ID, a validated vs. unvalidated string, a
+quantity in cents vs. a quantity in dollars, meters vs. feet. Mandatory
+wherever the language supports zero- or near-zero-cost wrapper types — see the
+per-language file for the concrete mechanism (Rust newtypes, TypeScript
+branded types, Python `NewType`).
+
 ## Guard rails
 
 Where a language lets you turn a whole class of runtime failure into a

--- a/home/skills/programming/defensive.md
+++ b/home/skills/programming/defensive.md
@@ -35,7 +35,10 @@ different things: two kinds of ID, a validated vs. unvalidated string, a
 quantity in cents vs. a quantity in dollars, meters vs. feet. Mandatory
 wherever the language supports zero- or near-zero-cost wrapper types — see the
 per-language file for the concrete mechanism (Rust newtypes, TypeScript
-branded types, Python `NewType`).
+branded types, Python `NewType`). This is a mechanical instruction; the
+design-level version of the same rule — recognising when two values are
+secretly different concepts in the first place — is the `design` skill's
+[data-and-state.md](../design/data-and-state.md).
 
 ## Guard rails
 

--- a/home/skills/programming/languages/nix.md
+++ b/home/skills/programming/languages/nix.md
@@ -1,14 +1,19 @@
 # Nix
 
 ## Repo shape
-- This flake uses the **dendritic pattern**: flake-parts + haumea. Files under
-  `flake-modules/` are auto-discovered — adding a file is enough, there is no
-  central import list to update.
-- Modules follow the options pattern: `options.<name>` plus
-  `config = lib.mkIf cfg.enable { ... }`.
-- Cross-file references go through flake outputs (`self.nixosModules.*`,
-  `self.homeModules.*`) and `self + "/path"`. **Never** relative imports
-  (`../../`).
+Flake layout varies a lot between repos — check what's actually there before
+assuming a convention. Common patterns you'll run into:
+- **Dendritic** (flake-parts + haumea, or similar): files under a modules
+  directory are auto-discovered — adding a file is enough, no central import
+  list. If the repo uses this, follow it; don't hand-roll an import list.
+- **Explicit imports**: a central `default.nix`/`flake.nix` lists every
+  module by path. Adding a file *does* require updating the list here.
+- Modules commonly follow the options pattern: `options.<name>` plus
+  `config = lib.mkIf cfg.enable { ... }` — but confirm the repo actually uses
+  it before assuming.
+- If the repo favors flake-output cross-references (`self.nixosModules.*`,
+  `self + "/path"`) over relative imports (`../../`), match that; grep for the
+  existing style rather than picking one.
 
 ## Rules
 - **DRY is enforced.** A value used twice (SSH keys, hostnames, ports, mandate
@@ -42,7 +47,7 @@
   `final.stdenv.hostPlatform.system`.
 
 ## Build loop
-`just build` (no activation) → `just test` (temporary) → `just switch`
-(permanent) → `just deploy` (remote, deploy-rs). See the `infra` skill's
-`nix.md` for the deployment side and the repo's `nix-config-workflows` skill
-for host/module/secret scaffolding.
+Build (no activation) → temporary activation → permanent switch → remote
+deploy, in increasing order of commitment. See the `infra` skill's `nix.md`
+for the actual commands (own or repo-wrapped) and check for a project-local
+workflow skill for host/module/secret scaffolding conventions.

--- a/home/skills/programming/languages/python.md
+++ b/home/skills/programming/languages/python.md
@@ -19,9 +19,9 @@
 - Dataclasses (or pydantic, if the project already uses it) instead of dicts
   for structured data that crosses a function boundary.
 - `typing.NewType` for identifiers/values that must not be mixed up despite
-  sharing a primitive type: `CustomerId = NewType("CustomerId", str)`. `def
-  f(customer_id: CustomerId, order_id: OrderId)` then makes a swapped call a
-  `mypy` error — plain `str`/`str` would not catch it, and this only helps
+  sharing a primitive type: `CustomerId = NewType("CustomerId", str)`.
+  `def f(customer_id: CustomerId, order_id: OrderId)` then makes a swapped
+  call a `mypy` error — plain `str`/`str` would not catch it, and this only helps
   under `mypy --strict` (see Toolchain above); it is erased at runtime like
   all Python type hints, so it is a static guard rail, not a validation one.
   Mandatory at any function boundary taking two or more same-typed values that

--- a/home/skills/programming/languages/python.md
+++ b/home/skills/programming/languages/python.md
@@ -5,6 +5,12 @@
   devshell. Do not `pip install` into the user profile.
 - Format with `ruff format`, lint with `ruff check`. Type-check with `mypy`
   where the project already has annotations.
+- Guard rail: on a new project (or a module you can annotate fully), run
+  `mypy --strict` rather than the default permissive mode — Python's type
+  system only catches what you've told it to check, so an unannotated
+  function is invisible to it. `pydantic`/`dataclass` at the boundary (see
+  Idioms below) is what makes an invalid input a validation error at parse
+  time instead of an `AttributeError` deep in the call stack.
 
 ## Idioms
 - Type-annotate every public function. Annotations are the documentation.

--- a/home/skills/programming/languages/python.md
+++ b/home/skills/programming/languages/python.md
@@ -18,6 +18,15 @@
   `shell=True` with interpolated values.
 - Dataclasses (or pydantic, if the project already uses it) instead of dicts
   for structured data that crosses a function boundary.
+- `typing.NewType` for identifiers/values that must not be mixed up despite
+  sharing a primitive type: `CustomerId = NewType("CustomerId", str)`. `def
+  f(customer_id: CustomerId, order_id: OrderId)` then makes a swapped call a
+  `mypy` error — plain `str`/`str` would not catch it, and this only helps
+  under `mypy --strict` (see Toolchain above); it is erased at runtime like
+  all Python type hints, so it is a static guard rail, not a validation one.
+  Mandatory at any function boundary taking two or more same-typed values that
+  mean different things — see `defensive.md`'s "distinct domain concepts"
+  rule.
 - Catch the specific exception. A bare `except Exception` needs a comment
   saying why the broad catch is correct and must re-raise or log with
   `exc_info=True`.

--- a/home/skills/programming/languages/rust.md
+++ b/home/skills/programming/languages/rust.md
@@ -12,7 +12,8 @@
 
 Deny the clippy `restriction`-group lints that catch panic-class bugs —
 `-D warnings` alone does not enable these; they are off by default and must be
-opted into. Add to the crate's (or workspace's) `Cargo.toml`:
+opted into. Add a `[lints.clippy]` table to the crate's (or workspace's)
+`Cargo.toml`:
 
 ```toml
 [lints.clippy]
@@ -26,6 +27,24 @@ unreachable = "deny"
 todo = "deny"
 unimplemented = "deny"
 get_unwrap = "deny"
+```
+
+`[lints.clippy]` needs Cargo 1.74+. On an older toolchain that can't be
+upgraded, use the equivalent crate-root attribute instead:
+
+```rust
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::unwrap_in_result,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unreachable,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::get_unwrap,
+)]
 ```
 
 This makes the existing "no `unwrap()`/`expect()` outside tests and `main`"

--- a/home/skills/programming/languages/rust.md
+++ b/home/skills/programming/languages/rust.md
@@ -50,8 +50,11 @@ upgraded, use the equivalent crate-root attribute instead:
 This makes the existing "no `unwrap()`/`expect()` outside tests and `main`"
 rule a lint failure instead of a review-time hope. For the narrow places that
 rule already permits — `main`'s top-level error handling, test modules — use
-a scoped `#[allow(clippy::unwrap_used, reason = "...")]` on the item, not a
-blanket crate-level allow; the lint should stay live everywhere else. Test
+a scoped `#[allow(clippy::unwrap_used)]` on the item, preceded by a `//`
+comment saying why, not a blanket crate-level allow — the lint should stay
+live everywhere else. (`reason = "..."` inside the attribute itself needs the
+nightly-only `lint_reasons` feature; a plain comment above the attribute is
+the stable equivalent.) Test
 modules commonly get `#![allow(clippy::unwrap_used, clippy::expect_used)]` at
 the `#[cfg(test)] mod tests` level, since panicking on bad test setup is the
 correct behaviour there.
@@ -59,9 +62,9 @@ correct behaviour there.
 `indexing_slicing` and `arithmetic_side_effects` will flag plenty of correct
 code (a loop indexing within a bound you just checked, a counter that cannot
 realistically overflow) — that is the point: replace `v[i]` with
-`v.get(i)` and handle the `None` case explicitly (or a scoped
-`#[allow(..., reason = "...")]` when a prior check truly makes it
-unreachable — see `defensive.md` on assertions vs error handling), and replace
+`v.get(i)` and handle the `None` case explicitly (or a scoped `#[allow(...)]`
+with a `//` comment above it when a prior check truly makes it unreachable —
+see `defensive.md` on assertions vs error handling), and replace
 unchecked `+`/`-`/`*` on values from outside this function with
 `checked_add`/`saturating_add`/etc. so the panic path is a deliberate, visible
 decision at each site rather than an accident of syntax.

--- a/home/skills/programming/languages/rust.md
+++ b/home/skills/programming/languages/rust.md
@@ -8,6 +8,45 @@
 - `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are the
   bar; run both before claiming a change is done.
 
+## Guard rails (mandatory)
+
+Deny the clippy `restriction`-group lints that catch panic-class bugs —
+`-D warnings` alone does not enable these; they are off by default and must be
+opted into. Add to the crate's (or workspace's) `Cargo.toml`:
+
+```toml
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+unwrap_in_result = "deny"
+panic = "deny"
+indexing_slicing = "deny"
+arithmetic_side_effects = "deny"
+unreachable = "deny"
+todo = "deny"
+unimplemented = "deny"
+get_unwrap = "deny"
+```
+
+This makes the existing "no `unwrap()`/`expect()` outside tests and `main`"
+rule a lint failure instead of a review-time hope. For the narrow places that
+rule already permits — `main`'s top-level error handling, test modules — use
+a scoped `#[allow(clippy::unwrap_used, reason = "...")]` on the item, not a
+blanket crate-level allow; the lint should stay live everywhere else. Test
+modules commonly get `#![allow(clippy::unwrap_used, clippy::expect_used)]` at
+the `#[cfg(test)] mod tests` level, since panicking on bad test setup is the
+correct behaviour there.
+
+`indexing_slicing` and `arithmetic_side_effects` will flag plenty of correct
+code (a loop indexing within a bound you just checked, a counter that cannot
+realistically overflow) — that is the point: replace `v[i]` with
+`v.get(i)` and handle the `None` case explicitly (or a scoped
+`#[allow(..., reason = "...")]` when a prior check truly makes it
+unreachable — see `defensive.md` on assertions vs error handling), and replace
+unchecked `+`/`-`/`*` on values from outside this function with
+`checked_add`/`saturating_add`/etc. so the panic path is a deliberate, visible
+decision at each site rather than an accident of syntax.
+
 ## Idioms
 - Errors: `thiserror` for library error enums, `anyhow` only at the binary
   edge. Every `?` boundary that crosses a subsystem gets `.context(...)`.

--- a/home/skills/programming/languages/rust.md
+++ b/home/skills/programming/languages/rust.md
@@ -54,7 +54,15 @@ decision at each site rather than an accident of syntax.
   the message says what the operator should do about it.
 - Prefer borrowed parameters (`&str`, `&[T]`) and return owned types. Clone
   when it makes the lifetime story simple; measure before optimising it away.
-- Newtypes over bare `String`/`u64` for identifiers that must not be mixed up.
+- **Newtypes over bare `String`/`u64`/`i32` for any identifier or measurement
+  that must not be mixed up with another of the same underlying type** —
+  `struct CustomerId(String)`, `struct OrderId(String)`, not two `String`
+  parameters. `fn f(customer_id: CustomerId, order_id: OrderId)` makes a
+  swapped-argument call a compile error instead of a runtime bug. Mandatory
+  at any function boundary taking two or more same-typed values that mean
+  different things — see `defensive.md`'s "distinct domain concepts" rule.
+  A `#[derive(...)]`'d unit struct is zero-cost; there is no runtime reason
+  not to.
 - `#[derive(Debug)]` on everything that can appear in an error path.
 
 ## Async

--- a/home/skills/programming/languages/typescript.md
+++ b/home/skills/programming/languages/typescript.md
@@ -14,6 +14,13 @@
 - `strict: true`. No `any` — use `unknown` plus a narrowing check when the
   shape is genuinely dynamic.
 - Discriminated unions instead of optional-field soup for state that has modes.
+- Branded types for identifiers/values that must not be mixed up despite
+  sharing a primitive type: `type CustomerId = string & { readonly __brand:
+  "CustomerId" }`, with a constructor function as the only way to produce one.
+  `f(customerId: CustomerId, orderId: OrderId)` then rejects a swapped call at
+  compile time — plain `string`/`string` would not. Mandatory at any function
+  boundary taking two or more same-typed values that mean different things —
+  see `defensive.md`'s "distinct domain concepts" rule.
 - Parse external data at the boundary (zod or an explicit validator) and pass
   typed values inward. Do not cast untrusted JSON with `as`.
 - `async`/`await` throughout; a floating promise is a bug — await it or

--- a/home/skills/programming/languages/typescript.md
+++ b/home/skills/programming/languages/typescript.md
@@ -5,7 +5,7 @@
   and authoritative; never regenerate it as a side effect of another change.
 - `tsc --noEmit` clean is the bar, alongside the project's linter.
 - Guard rail: enable `noUncheckedIndexedAccess` in `tsconfig.json`. Without it,
-  `arr[i]`/`obj[key]` type as the value type, not `T | undefined` — the
+  `arr[i]`/`obj[key]` types as the value type, not `T | undefined` — the
   equivalent of Rust's unchecked indexing panic, except here it's a silent
   `undefined` that surfaces as a crash three calls later instead of at the
   access site.

--- a/home/skills/programming/languages/typescript.md
+++ b/home/skills/programming/languages/typescript.md
@@ -15,8 +15,9 @@
   shape is genuinely dynamic.
 - Discriminated unions instead of optional-field soup for state that has modes.
 - Branded types for identifiers/values that must not be mixed up despite
-  sharing a primitive type: `type CustomerId = string & { readonly __brand:
-  "CustomerId" }`, with a constructor function as the only way to produce one.
+  sharing a primitive type:
+  `type CustomerId = string & { readonly __brand: "CustomerId" }`, with a
+  constructor function as the only way to produce one.
   `f(customerId: CustomerId, orderId: OrderId)` then rejects a swapped call at
   compile time — plain `string`/`string` would not. Mandatory at any function
   boundary taking two or more same-typed values that mean different things —

--- a/home/skills/programming/languages/typescript.md
+++ b/home/skills/programming/languages/typescript.md
@@ -4,6 +4,11 @@
 - Node and package manager come from the flake devshell. Lockfile is committed
   and authoritative; never regenerate it as a side effect of another change.
 - `tsc --noEmit` clean is the bar, alongside the project's linter.
+- Guard rail: enable `noUncheckedIndexedAccess` in `tsconfig.json`. Without it,
+  `arr[i]`/`obj[key]` type as the value type, not `T | undefined` — the
+  equivalent of Rust's unchecked indexing panic, except here it's a silent
+  `undefined` that surfaces as a crash three calls later instead of at the
+  access site.
 
 ## Idioms
 - `strict: true`. No `any` — use `unknown` plus a narrowing check when the

--- a/home/skills/repo-audit/branch-protection.md
+++ b/home/skills/repo-audit/branch-protection.md
@@ -12,14 +12,14 @@ Run via `scripts/checks/branch-protection.sh <target>`.
   has no second identity to approve it either. Required status checks are the
   real gate there instead. The check calls `gh api repos/{owner}/{repo}/
   collaborators` to decide which branch applies — found this the hard way
-  applying it to nix-config itself.
+  applying it to a solo repo.
 - Required status checks configured, and the check names actually match a
   **job id** (or `name:`) in the repo's current CI workflows — a required
   check pointing at a renamed or deleted job is a silent no-op, worse than no
   requirement. Matched against job ids read from the workflow YAML, not
   workflow filenames — a job called `flake-check` living in `pr-check.yaml`
   is a match, not a mismatch; comparing against the filename was an earlier
-  bug that flagged this repo's own correctly-configured check as stale.
+  bug that flagged a correctly-configured check as stale.
 - Force-push disabled on the default branch.
 - Branch deletion protection enabled on the default branch.
 - Merge-strategy policy (squash / rebase / merge-commit) is **reported, not

--- a/home/skills/repo-audit/branch-protection.md
+++ b/home/skills/repo-audit/branch-protection.md
@@ -6,13 +6,13 @@ Run via `scripts/checks/branch-protection.sh <target>`.
 
 - Required PR reviews on the default branch (at least one approving review) —
   **skipped, not failed, on a solo repo (1 collaborator)**. GitHub does not
-  count self-approval toward a required review, so `required_approving_
-  review_count >= 1` on a single-collaborator repo locks that collaborator
-  out of merging anything, including Renovate/Dependabot automerge, which
-  has no second identity to approve it either. Required status checks are the
-  real gate there instead. The check calls `gh api repos/{owner}/{repo}/
-  collaborators` to decide which branch applies — found this the hard way
-  applying it to a solo repo.
+  count self-approval toward a required review, so
+  `required_approving_review_count >= 1` on a single-collaborator repo locks
+  that collaborator out of merging anything, including Renovate/Dependabot
+  automerge, which has no second identity to approve it either. Required
+  status checks are the real gate there instead. The check calls
+  `gh api repos/{owner}/{repo}/collaborators` to decide which branch applies —
+  found this the hard way applying it to a solo repo.
 - Required status checks configured, and the check names actually match a
   **job id** (or `name:`) in the repo's current CI workflows — a required
   check pointing at a renamed or deleted job is a silent no-op, worse than no

--- a/home/skills/repo-audit/ci-pipeline.md
+++ b/home/skills/repo-audit/ci-pipeline.md
@@ -13,14 +13,12 @@ Run via `scripts/checks/ci-pipeline.sh <target>`.
   `contents: read` explicitly rather than inheriting an org-wide default.
 - Basic caching present for the ecosystem in use (e.g. `actions/cache` or a
   language-specific cache action for Go modules/npm/Cargo; Nix builds caching
-  via a binary cache or `cachix`/`niks3`-style push, matching this repo's own
-  `build-and-cache.yaml` pattern).
+  via a binary cache or a `cachix`/self-hosted-push-style workflow).
 - At least one workflow triggers on `pull_request` (or `pull_request_target`).
-  A repo whose CI is entirely push/tag/schedule/dispatch-triggered — this
-  repo's own state before `pr-check.yaml` was added — can never satisfy a
-  required status check on a PR, which silently breaks both branch protection
-  and Renovate automerge-on-green: they'd wait forever on a status that never
-  reports, not fail loudly. Caught this the hard way while wiring up
+  A repo whose CI is entirely push/tag/schedule/dispatch-triggered can never
+  satisfy a required status check on a PR, which silently breaks both branch
+  protection and Renovate automerge-on-green: they'd wait forever on a status
+  that never reports, not fail loudly. Caught this the hard way while wiring up
   `dependency-updates.md`'s automerge requirement.
 
 ## GitHub

--- a/home/skills/repo-audit/ci-pipeline.md
+++ b/home/skills/repo-audit/ci-pipeline.md
@@ -8,9 +8,10 @@ Run via `scripts/checks/ci-pipeline.sh <target>`.
   corresponds to a job that actually exists in the current CI config — checked
   both directions: no stale required check, and no CI job that plainly should
   be required but isn't.
-- Workflow permissions are least-privilege: no default `permissions:
-  write-all` at the workflow level; jobs that don't need write access declare
-  `contents: read` explicitly rather than inheriting an org-wide default.
+- Workflow permissions are least-privilege: no default
+  `permissions: write-all` at the workflow level; jobs that don't need write
+  access declare `contents: read` explicitly rather than inheriting an
+  org-wide default.
 - Basic caching present for the ecosystem in use (e.g. `actions/cache` or a
   language-specific cache action for Go modules/npm/Cargo; Nix builds caching
   via a binary cache or a `cachix`/self-hosted-push-style workflow).

--- a/home/skills/repo-audit/dev-shell.md
+++ b/home/skills/repo-audit/dev-shell.md
@@ -5,12 +5,13 @@ involved.
 
 ## Criteria
 
-- `flake.nix` present at repo root. If the user's convention is Nix-based dev
-  environments (no bare Dockerfiles, no assumed global toolchains — see
-  `programming/languages/rust.md`'s "build with Nix" convention), a missing
-  `flake.nix` is itself a finding, not a skip, regardless of what language the
-  repo is in. If that convention doesn't apply here, skip this criterion
-  instead of reporting it.
+- `flake.nix` present at repo root. Nix-based dev environments are a personal
+  convention (no bare Dockerfiles, no assumed global toolchains — see
+  `programming/languages/rust.md`'s "build with Nix" convention), **not a
+  universal standard** — a missing `flake.nix` is reported as a skip
+  (suggestion, not a failure) so this doesn't manufacture noise on repos,
+  teams, or workplaces that haven't adopted Nix. The rest of this criterion
+  only evaluates once a `flake.nix` already exists.
 - `devShells.<system>.default` (or at least one named dev shell) exists, and
   provides the toolchain actually needed to build/test the repo.
 - `packages.<system>.default` (or at least one named package) exists **in the
@@ -32,9 +33,9 @@ GitLab, or no forge at all (a plain local clone).
 
 ## Fixing
 
-`--fix` never invents a devShell/package definition from nothing — that
-requires knowing the repo's actual toolchain, which is a judgment call, not a
-mechanical fix. Instead it: scaffolds a `.envrc` with `use flake` when
-`flake.nix` already exists but `.envrc` doesn't, and reports (without writing)
-a starting-point `flake.nix` skeleton for the detected language — for the
-user to review and commit themselves.
+`--fix` never invents a devShell/package/flake.nix definition from nothing —
+that requires knowing the repo's actual toolchain, which is a judgment call,
+not a mechanical fix. It only scaffolds a `.envrc` with `use flake`, and only
+when `flake.nix` already exists but `.envrc` doesn't — a missing `flake.nix`
+itself is left as a skip/suggestion (see Criteria above) for the user to
+write and commit themselves.

--- a/home/skills/repo-audit/dev-shell.md
+++ b/home/skills/repo-audit/dev-shell.md
@@ -5,11 +5,12 @@ involved.
 
 ## Criteria
 
-- `flake.nix` present at repo root. If it is missing entirely, that is itself
-  a finding, not a skip — Nix packaging is this house's standard way to build
-  and develop software (no bare Dockerfiles, no assumed global toolchains; see
-  `programming/languages/rust.md`'s "build with Nix" convention), so a repo
-  without one is reported as needing it, regardless of what language it's in.
+- `flake.nix` present at repo root. If the user's convention is Nix-based dev
+  environments (no bare Dockerfiles, no assumed global toolchains — see
+  `programming/languages/rust.md`'s "build with Nix" convention), a missing
+  `flake.nix` is itself a finding, not a skip, regardless of what language the
+  repo is in. If that convention doesn't apply here, skip this criterion
+  instead of reporting it.
 - `devShells.<system>.default` (or at least one named dev shell) exists, and
   provides the toolchain actually needed to build/test the repo.
 - `packages.<system>.default` (or at least one named package) exists **in the
@@ -18,9 +19,9 @@ involved.
   mechanisms.
 - `.envrc` present at repo root and wires up the flake's dev shell — `use
   flake`/`use nix`, or an equivalent hand-rolled `nix print-dev-env`/`nix
-  develop` invocation (this repo's own `.envrc` skips the stock `use flake`
-  gcroot-per-input behavior for cold-reload speed; that's a valid variant, not
-  a finding), so `direnv` picks up the shell automatically on `cd`.
+  develop` invocation (a repo may skip the stock `use flake` gcroot-per-input
+  behavior for cold-reload speed; that's a valid variant, not a finding), so
+  `direnv` picks up the shell automatically on `cd`.
 - Onboarding docs (`README.md` / `CONTRIBUTING.md`) mention `direnv allow` (or
   equivalent) so a new contributor knows the step exists.
 
@@ -35,6 +36,5 @@ GitLab, or no forge at all (a plain local clone).
 requires knowing the repo's actual toolchain, which is a judgment call, not a
 mechanical fix. Instead it: scaffolds a `.envrc` with `use flake` when
 `flake.nix` already exists but `.envrc` doesn't, and reports (without writing)
-a starting-point `flake.nix` skeleton — matching one of this repo's own
-`templates/<lang>/` scaffolds where the ecosystem matches — for the user to
-review and commit themselves.
+a starting-point `flake.nix` skeleton for the detected language — for the
+user to review and commit themselves.

--- a/home/skills/repo-audit/dev-shell.md
+++ b/home/skills/repo-audit/dev-shell.md
@@ -18,10 +18,11 @@ involved.
   same flake**, and `nix build .#<package>` succeeds — the flake is expected
   to serve both roles (dev shell and package build), not split across two
   mechanisms.
-- `.envrc` present at repo root and wires up the flake's dev shell — `use
-  flake`/`use nix`, or an equivalent hand-rolled `nix print-dev-env`/`nix
-  develop` invocation (a repo may skip the stock `use flake` gcroot-per-input
-  behavior for cold-reload speed; that's a valid variant, not a finding), so
+- `.envrc` present at repo root and wires up the flake's dev shell —
+  `use flake`/`use nix`, or an equivalent hand-rolled
+  `nix print-dev-env`/`nix develop` invocation (a repo may skip the stock
+  `use flake` gcroot-per-input behavior for cold-reload speed; that's a valid
+  variant, not a finding), so
   `direnv` picks up the shell automatically on `cd`.
 - Onboarding docs (`README.md` / `CONTRIBUTING.md`) mention `direnv allow` (or
   equivalent) so a new contributor knows the step exists.

--- a/home/skills/repo-audit/release-management.md
+++ b/home/skills/repo-audit/release-management.md
@@ -10,11 +10,10 @@ Run via `scripts/checks/release-management.sh <target>`.
   `python-semantic-release`/similar) elsewhere, or on GitLab where
   release-please has no native support.
 - Commit messages / PR titles conform to the convention the tool consumes —
-  Conventional Commits (`feat:`, `fix:`, ...) — matching this repo's own
-  atomic-commit mandate. Checked heuristically against recent commit history
-  (last ~50 commits on the default branch), not enforced as a commit-msg hook
-  by this check (that's `pre-commit.md`'s territory if the repo chooses to add
-  one).
+  Conventional Commits (`feat:`, `fix:`, ...). Checked heuristically against
+  recent commit history (last ~50 commits on the default branch), not
+  enforced as a commit-msg hook by this check (that's `pre-commit.md`'s
+  territory if the repo chooses to add one).
 - Releases actually publish on merge to the default branch — a release-please
   workflow that only opens a release PR nobody merges is a finding, not a
   pass. Checked by confirming the workflow both opens release PRs and, on

--- a/home/skills/repo-audit/release-management.md
+++ b/home/skills/repo-audit/release-management.md
@@ -5,9 +5,10 @@ Run via `scripts/checks/release-management.sh <target>`.
 ## Criteria
 
 - Automated release tooling present and wired into CI: `release-please` on
-  GitHub (a `.github/workflows/*.yaml` running `googleapis/release-please-
-  action`, or a `release-please-config.json`); `semantic-release` (or
-  `python-semantic-release`/similar) elsewhere, or on GitLab where
+  GitHub (a `.github/workflows/*.yaml` running
+  `googleapis/release-please-action`, or a `release-please-config.json`);
+  `semantic-release` (or `python-semantic-release`/similar) elsewhere, or on
+  GitLab where
   release-please has no native support.
 - Commit messages / PR titles conform to the convention the tool consumes —
   Conventional Commits (`feat:`, `fix:`, ...). Checked heuristically against

--- a/home/skills/repo-audit/scripts/checks/dev-shell.sh
+++ b/home/skills/repo-audit/scripts/checks/dev-shell.sh
@@ -37,7 +37,7 @@ main() {
     echo "== dev-shell ($target) =="
 
     if [[ ! -f "$target/flake.nix" ]]; then
-        report_fail "no flake.nix found — Nix packaging is the house standard for dev shell + build"
+        report_skip "no flake.nix found — Nix packaging is a personal convention, not enforced here; suggest it, don't fail on it"
         echo "-- $FINDINGS_COUNT finding(s) --"
         return 0
     fi

--- a/home/skills/repo-audit/scripts/tests/dev-shell.test.sh
+++ b/home/skills/repo-audit/scripts/tests/dev-shell.test.sh
@@ -16,11 +16,13 @@ TARGET="$TESTS_DIR/../checks/dev-shell.sh"
 # shellcheck source=/dev/null
 . "$TARGET"
 
-test_main_flags_missing_flake() {
+test_main_skips_missing_flake() {
     local repo; repo="$(make_fixture_repo)"
     local out
     out="$(main "$repo" 2>&1)"
-    assert_contains "$out" "no flake.nix found" "main: flags a repo with no flake.nix at all"
+    assert_contains "$out" "no flake.nix found" "main: notes a repo with no flake.nix at all"
+    assert_contains "$out" "SKIP" "main: missing flake.nix is a skip/suggestion, not a failure"
+    assert_contains "$out" "-- 0 finding(s) --" "main: missing flake.nix doesn't count as a finding"
     rm -rf "$repo"
 }
 
@@ -83,7 +85,7 @@ test_fix_scaffolds_envrc_on_confirm() {
 }
 
 run_all() {
-    test_main_flags_missing_flake
+    test_main_skips_missing_flake
     test_main_flags_missing_devshell_and_package
     test_main_passes_devshell_and_package_when_both_present
     test_main_accepts_hand_rolled_envrc

--- a/home/skills/testing/languages/nix.md
+++ b/home/skills/testing/languages/nix.md
@@ -4,16 +4,20 @@
 - **Evaluation**: `nix flake check` catches eval errors and runs any flake
   checks (deploy-rs checks, custom checks, etc). Note that a broken input for
   one platform (e.g. a Darwin-only or otherwise platform-gated derivation) can
-  fail the whole check from the wrong host — skipping it (`--skip-checks` if
-  the repo wraps this, or excluding the failing check) is legitimate there,
-  but say so rather than hiding it.
+  fail the whole check from the wrong host. `nix flake check` has no flag to
+  exclude one check — the legitimate move is either `--skip-checks` if the
+  repo wraps this, or building the specific checks you actually want
+  (`nix build .#checks.<system>.<name>` per check) instead of the aggregate
+  command; say which you did rather than hiding it.
 - **Build**: build a host's/target's toplevel without activating (raw
   `nixos-rebuild build --flake .#<host>`, or the repo's own wrapper if one
   exists — check `infra/nix.md`). This is the cheapest real proof that a
   module change is sound.
-- **Activation**: a temporary activation (`nixos-rebuild test`/`darwin-rebuild
-  test` or repo wrapper) that reverts on reboot — the safe way to try a
-  change that could break boot or display.
+- **Activation**: a temporary activation — `nixos-rebuild test --flake
+  .#<host>` (or repo wrapper) reverts on reboot, the safe way to try a change
+  that could break boot or display. nix-darwin has no equivalent: `darwin-
+  rebuild switch --flake .#<host>` activates immediately and permanently, so
+  build first and review the diff instead of relying on a revert.
 - **VM**: `nixos-rebuild build-vm --flake .#<host>` (the `--flake .#<host>`
   matters — omitting it silently builds the wrong/default configuration in a
   flake-based repo), or a `nixosTest`/VM-build wrapper the repo provides, for

--- a/home/skills/testing/languages/nix.md
+++ b/home/skills/testing/languages/nix.md
@@ -1,17 +1,22 @@
 # Testing Nix
 
 ## Levels
-- **Evaluation**: `nix flake check` catches eval errors and runs the deploy-rs
-  checks. Note that a broken input for one platform (for example a Darwin or
-  Asahi-only derivation) can fail the whole check from the wrong host —
-  `--skip-checks` is legitimate there, but say so rather than hiding it.
-- **Build**: `just build <hostname>` builds a host's toplevel without
-  activating. This is the cheapest real proof that a module change is sound.
-- **Activation**: `just test` activates temporarily and reverts on reboot —
-  the safe way to try a change that could break boot or display.
-- **VM**: `just test-build <hostname>` then `just test-run <hostname>` for a
-  full boot in a VM, which is the only way to test boot-path and disk changes
-  without risking the machine.
+- **Evaluation**: `nix flake check` catches eval errors and runs any flake
+  checks (deploy-rs checks, custom checks, etc). Note that a broken input for
+  one platform (e.g. a Darwin-only or otherwise platform-gated derivation) can
+  fail the whole check from the wrong host — skipping it (`--skip-checks` if
+  the repo wraps this, or excluding the failing check) is legitimate there,
+  but say so rather than hiding it.
+- **Build**: build a host's/target's toplevel without activating (raw
+  `nixos-rebuild build --flake .#<host>`, or the repo's own wrapper if one
+  exists — check `infra/nix.md`). This is the cheapest real proof that a
+  module change is sound.
+- **Activation**: a temporary activation (`nixos-rebuild test`/`darwin-rebuild
+  test` or repo wrapper) that reverts on reboot — the safe way to try a
+  change that could break boot or display.
+- **VM**: `nixos-rebuild build-vm` (or a `nixosTest`/VM-build wrapper the repo
+  provides) for a full boot in a VM — the only way to test boot-path and disk
+  changes without risking the machine.
 
 ## Practice
 - `git add` new files before any of the above; flakes ignore untracked files

--- a/home/skills/testing/languages/nix.md
+++ b/home/skills/testing/languages/nix.md
@@ -13,11 +13,12 @@
   `nixos-rebuild build --flake .#<host>`, or the repo's own wrapper if one
   exists — check `infra/nix.md`). This is the cheapest real proof that a
   module change is sound.
-- **Activation**: a temporary activation — `nixos-rebuild test --flake
-  .#<host>` (or repo wrapper) reverts on reboot, the safe way to try a change
-  that could break boot or display. nix-darwin has no equivalent: `darwin-
-  rebuild switch --flake .#<host>` activates immediately and permanently, so
-  build first and review the diff instead of relying on a revert.
+- **Activation**: a temporary activation —
+  `nixos-rebuild test --flake .#<host>` (or repo wrapper) reverts on reboot,
+  the safe way to try a change that could break boot or display. nix-darwin
+  has no equivalent: `darwin-rebuild switch --flake .#<host>` activates
+  immediately and permanently, so build first and review the diff instead of
+  relying on a revert.
 - **VM**: `nixos-rebuild build-vm --flake .#<host>` (the `--flake .#<host>`
   matters — omitting it silently builds the wrong/default configuration in a
   flake-based repo), or a `nixosTest`/VM-build wrapper the repo provides, for

--- a/home/skills/testing/languages/nix.md
+++ b/home/skills/testing/languages/nix.md
@@ -14,9 +14,11 @@
 - **Activation**: a temporary activation (`nixos-rebuild test`/`darwin-rebuild
   test` or repo wrapper) that reverts on reboot — the safe way to try a
   change that could break boot or display.
-- **VM**: `nixos-rebuild build-vm` (or a `nixosTest`/VM-build wrapper the repo
-  provides) for a full boot in a VM — the only way to test boot-path and disk
-  changes without risking the machine.
+- **VM**: `nixos-rebuild build-vm --flake .#<host>` (the `--flake .#<host>`
+  matters — omitting it silently builds the wrong/default configuration in a
+  flake-based repo), or a `nixosTest`/VM-build wrapper the repo provides, for
+  a full boot in a VM — the only way to test boot-path and disk changes
+  without risking the machine.
 
 ## Practice
 - `git add` new files before any of the above; flakes ignore untracked files


### PR DESCRIPTION
## Summary
Global skills (`~/.claude/skills/`, sourced from `home/skills/`) are meant to work across many projects, not just this repo. This PR started as a wording cleanup and grew — see commits for the full breakdown:

- **Genericize Nix-specific wording**: `infra/nix.md`, `programming/languages/nix.md`, `testing/languages/nix.md` no longer present this repo's justfile aliases, deploy-rs, or the dendritic pattern as universal Nix conventions.
- **De-anecdote repo-audit**: removed "this repo"/"nix-config itself" framing from `repo-audit/*.md` criteria (repo-audit runs against arbitrary target repos).
- **repo-audit dev-shell check no longer hard-fails non-Nix repos**: `dev-shell.sh` now `report_skip`s (not `report_fail`) a missing `flake.nix` — Nix packaging is a personal convention, barely adopted at work yet, not a universal standard to enforce on every audited repo.
- **New: mandatory guard-rails guidance in the `programming` skill** (`defensive.md` + per-language files): deny clippy's panic-class restriction lints in Rust (`[lints.clippy]`, with a pre-1.74-Cargo fallback), `mypy --strict` / `noUncheckedIndexedAccess` guard rails for Python/TypeScript, and a mandate to give distinct domain concepts (e.g. a customer ID vs. an order ID) distinct types so a swapped-argument bug is a compile error, not a runtime one — cross-linked into the `design` skill's `data-and-state.md`.
- **Accuracy fixes from Copilot review**: corrected nix-darwin/home-manager verb-parity claims, `nix flake check`'s lack of a per-check exclude flag, missing `--flake .#<host>` on the Activation example, and a grammar nit.

## Test plan
- [x] Read every edited file after each change to confirm no remaining nix-config-specific assumptions
- [x] `dev-shell.sh` + all repo-audit test suites pass (90 assertions) after the skip-not-fail behavior change
- [x] Addressed and resolved all Copilot review threads
- Docs-only change otherwise, no build/eval affected