### PR TITLE
fix(cavemem): update npmDepsHash for better-sqlite3 v13

### DIFF
--- a/pkgs/cavemem/default.nix
+++ b/pkgs/cavemem/default.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
 
   inherit src;
 
-  npmDepsHash = "sha256-7TtsqNZPE50+Et3mg0q9lGPqjv9fpfKJZxJqMJT6Z2w=";
+  npmDepsHash = "sha256-yQVbrGeXsPyBTvAH415nc31ufZRjudrgM1lt0njU+MA=";
 
   # dist/ is pre-built in the npm tarball; skip the TypeScript build step
   dontNpmBuild = true;


### PR DESCRIPTION
## Summary
- Renovate PR #197 bumped `better-sqlite3` to v13 in `pkgs/cavemem/package-lock.json` without updating the pinned `npmDepsHash`, breaking every `ali-desktop` system build with "npmDepsHash is out of date".
- Repins `npmDepsHash` to the correct value for the current lockfile.

## Test plan
- [x] `nix build ".#nixosConfigurations.ali-desktop.config.system.build.toplevel" --no-link` completes successfully (previously failed on this derivation).

https://claude.ai/code/session_01Es9MAdiDFvksTYAbhsMZQZ