### PR TITLE
fix(home-storage-server-1): mergerfs getattr=newest + ghost-dentry watchdog

### DIFF
--- a/flake-modules/hosts/home-storage-server-1/default.nix
+++ b/flake-modules/hosts/home-storage-server-1/default.nix
@@ -42,6 +42,141 @@ in {
         mergerfsBranchMounts = map (mp: "${utils.escapeSystemdPath mp}.mount")
           (builtins.filter (lib.hasPrefix "/media/disks/")
             (builtins.attrNames config.fileSystems));
+
+        # Self-healing watchdog for ghost dentries / stale mergerfs views (see
+        # the media-storage-watchdog systemd unit below for the incident this
+        # guards against). shellcheck-clean via writeShellApplication; every
+        # runtime dep is declared, nothing assumed off PATH.
+        mediaStorageWatchdogScript = pkgs.writeShellApplication {
+          name = "media-storage-watchdog";
+          runtimeInputs = [ pkgs.coreutils pkgs.findutils pkgs.util-linux pkgs.systemd pkgs.nfs-utils ];
+          text = ''
+            # Probe directory for the ghost-dentry check: a real, populated
+            # subtree behind the union that every branch can contribute to.
+            probe_dir="/media/storage/media/Movies"
+            mount_unit="media-storage.mount"
+            nfs_unit="nfs-server.service"
+            # A hung FUSE/NFS call must never hang the watchdog itself.
+            probe_timeout=15
+            # At most one restart per flap window: home-storage-server-1 runs
+            # this every 2 minutes, and a flapping fault (e.g. a disk mid-
+            # rescan) restarting the export every cycle would itself cause
+            # client-visible churn. Persisted under systemd's StateDirectory
+            # so it survives across timer-triggered runs.
+            flap_window_secs=1800
+            state_dir="''${STATE_DIRECTORY:-/var/lib/media-storage-watchdog}"
+            last_restart_file="$state_dir/last-restart"
+
+            fault=""
+
+            log() {
+              # Single-line, greppable: `journalctl -u media-storage-watchdog | grep FAULT`.
+              echo "media-storage-watchdog: $*"
+            }
+
+            check_mounts() {
+              if ! timeout "$probe_timeout" mountpoint -q /media/storage; then
+                fault="union-not-mounted /media/storage"
+                return 1
+              fi
+              # Every branch dir that currently exists under /media/disks/ is
+              # expected to have its own filesystem mounted onto it (NixOS
+              # only creates the mountpoint directory for a configured
+              # fileSystems entry) -- derived from what's on disk, not from a
+              # hardcoded disk-serial list, so it tracks disk add/remove for
+              # free.
+              for branch in /media/disks/*/; do
+                [ -d "$branch" ] || continue
+                if ! timeout "$probe_timeout" mountpoint -q "$branch"; then
+                  fault="branch-not-mounted ''${branch%/}"
+                  return 1
+                fi
+              done
+              return 0
+            }
+
+            check_ghosts_and_read() {
+              local entries entry sample_file=""
+              # This is exactly the observed failure signature: readdir lists
+              # the entry, lookup (stat) then fails on it.
+              entries=$(timeout "$probe_timeout" find "$probe_dir" -mindepth 1 -maxdepth 1 2>/dev/null | head -n 25) || true
+              if [ -z "$entries" ]; then
+                fault="probe-dir-empty-or-unreadable $probe_dir"
+                return 1
+              fi
+              while IFS= read -r entry; do
+                [ -n "$entry" ] || continue
+                if ! timeout "$probe_timeout" stat "$entry" >/dev/null 2>&1; then
+                  fault="ghost-dentry $entry"
+                  return 1
+                fi
+                if [ -z "$sample_file" ] && [ -f "$entry" ]; then
+                  sample_file="$entry"
+                fi
+              done <<< "$entries"
+
+              # Read probe: catches a union that lists and stats fine but is
+              # wedged on actual I/O. The depth-1 entries under Movies are all
+              # DIRECTORIES (one per film), so the loop above never sets
+              # sample_file — reach one level deeper for a real media file.
+              if [ -z "$sample_file" ]; then
+                sample_file=$(timeout "$probe_timeout" find "$probe_dir" -mindepth 2 -maxdepth 2 -type f 2>/dev/null | head -n 1) || true
+              fi
+              if [ -n "$sample_file" ]; then
+                if ! timeout "$probe_timeout" dd if="$sample_file" of=/dev/null bs=4096 count=1 status=none; then
+                  fault="read-probe-failed $sample_file"
+                  return 1
+                fi
+              fi
+              return 0
+            }
+
+            run_probes() {
+              fault=""
+              check_mounts && check_ghosts_and_read
+            }
+
+            mkdir -p "$state_dir"
+
+            if run_probes; then
+              exit 0
+            fi
+
+            log "FAULT $fault"
+
+            now=$(date +%s)
+            last_restart=0
+            if [ -f "$last_restart_file" ]; then
+              last_restart=$(cat "$last_restart_file")
+            fi
+            elapsed=$((now - last_restart))
+
+            if [ "$elapsed" -lt "$flap_window_secs" ]; then
+              log "FAULT-SUPPRESSED $fault (last restart ''${elapsed}s ago, window ''${flap_window_secs}s)"
+              exit 1
+            fi
+
+            echo "$now" > "$last_restart_file"
+            log "restarting $mount_unit + $nfs_unit for: $fault"
+            # nfsd (and smbd) hold the FUSE mount open, so restarting
+            # media-storage.mount while nfs-server is still up fails "target
+            # is busy" (see the scsi-rescan-and-mount comment above) -- stop
+            # the NFS export first to release the hold, remount the union,
+            # then bring the export back (which re-reads exportfs config).
+            systemctl stop "$nfs_unit" || true
+            systemctl restart "$mount_unit" || true
+            systemctl start "$nfs_unit" || true
+            exportfs -ra 2>/dev/null || true
+
+            if run_probes; then
+              log "RECOVERED $fault"
+              exit 0
+            else
+              log "PERSISTENT-FAULT $fault (still failing after restart)"
+              exit 1
+            fi
+          '';
+        };
       in
       {
         modules.nohang = {
@@ -338,6 +473,37 @@ in {
           timerConfig = {
             OnBootSec = "90s";
             OnUnitActiveSec = "60s";
+            AccuracySec = "10s";
+          };
+        };
+
+        # Ghost-dentry watchdog: catches the OTHER way this pool goes silently
+        # wrong, distinct from media-pool-watchdog above. That one detects the
+        # union being fully unmounted; this one detects the union staying
+        # *mounted* while serving stale/broken views -- readdir lists an
+        # entry that lookup then can't stat (ghost dentry / stale view). Seen
+        # 2026-08-22 (and once 2026-07): mergerfs kept answering, so
+        # media-pool-watchdog's `findmnt` check stayed green, but pharos's
+        # library scans silently broke because listed files 404'd on stat.
+        # The fix both times was restarting the mount + NFS export, so this
+        # automates exactly that and reports whether it worked. Script body
+        # lives in the outer `let` (mediaStorageWatchdogScript) alongside the
+        # other derived host values.
+        systemd.services.media-storage-watchdog = {
+          description = "Detect + heal ghost dentries / stale views on the mergerfs union";
+          after = [ "media-storage.mount" "nfs-server.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${mediaStorageWatchdogScript}/bin/media-storage-watchdog";
+            StateDirectory = "media-storage-watchdog";
+          };
+        };
+        systemd.timers.media-storage-watchdog = {
+          description = "Periodic ghost-dentry / stale-view check";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnBootSec = "2min";
+            OnUnitActiveSec = "2min";
             AccuracySec = "10s";
           };
         };

--- a/flake-modules/hosts/home-storage-server-1/hardware-configuration.nix
+++ b/flake-modules/hosts/home-storage-server-1/hardware-configuration.nix
@@ -161,6 +161,20 @@
           # it's a runtime control only, so it is intentionally omitted here.
           "cache.readdir=true"
           "nfsopenhack=all"
+          # Merged-dir attributes must come from the NEWEST branch, not the
+          # first found (the default, ff). With ff, a dir that exists on
+          # several branches reports the mtime of whichever branch sorts
+          # first; writing a file onto a DIFFERENT branch then never bumps
+          # the merged dir's mtime, and NFS clients — which invalidate their
+          # cached readdir pages only on a dir mtime change (lookupcache=none
+          # does not cover readdir) — serve a stale listing indefinitely.
+          # Seen 2026-08-22: a replaced movie was invisible to the k8s
+          # clients (ghost old entries, no new file) until the stale
+          # duplicate dirs were removed by hand (pharos B201 incident).
+          # newest costs a getattr against each branch holding the path,
+          # acceptable on this pool; it makes any branch's change visible in
+          # the merged attributes.
+          "func.getattr=newest"
           # Parallel branch readdir. Default func.readdir=seq walks all 16
           # branches one-at-a-time, so a cold-cache readdir takes seconds while
           # disks spin up -> the stall window where clients see truncated/empty


### PR DESCRIPTION
Two changes from the 2026-08-22 stale-listing incident (a replaced movie was invisible to the k8s NFS clients; pharos B201):

1. **`func.getattr=newest`** on the mergerfs union — with the default first-found policy, a dir existing on several branches reports a stale branch's mtime, so a write landing on a different branch never bumps the merged dir mtime and NFS clients keep their cached readdir pages forever. Already applied live via runtime xattr; this persists it.
2. **media-storage-watchdog** — 2-min systemd timer probing mount state, readdir-then-stat (the exact ghost-dentry signature), and a 4KiB read through the union; on fault it restarts `media-storage.mount` + `nfs-server.service` (NFS stopped first — it holds the FUSE mount open), at most once per 30 min, with greppable FAULT/RECOVERED journal lines.

Host eval: `nix build .#nixosConfigurations.home-storage-server-1...toplevel --dry-run` clean; watchdog script shellcheck-clean via writeShellApplication.

Not deployed — runtime xattr covers the getattr fix until the next planned deploy of hss1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)