### PR TITLE
feat(mangohud): per-host VRR-friendly fps cap

### DIFF
--- a/flake-modules/hosts/ali-desktop/default.nix
+++ b/flake-modules/hosts/ali-desktop/default.nix
@@ -110,6 +110,10 @@ in {
             autoVrr = false;
           };
 
+          # Samsung G9 (DP-2) tops out at 120Hz; caps games at 116fps so VRR
+          # stays engaged instead of bouncing off the vsync ceiling.
+          custom.mangohud.displayMaxRefresh = 120;
+
           # Forces OpenAL Soft to stereo output. Without this, OpenAL's
           # PulseAudio backend falls back to mono on the Scarlett 2i2's
           # pro-audio profile (aux0,aux1 channel map is not recognized),

--- a/home/programs/linux-only/mangohud/MangoHud.conf
+++ b/home/programs/linux-only/mangohud/MangoHud.conf
@@ -28,7 +28,6 @@ font_size=24
 fps
 fps_color=B22222,FDFD09,39F900
 fps_color_change
-fps_limit=0
 fps_limit_method=late
 fps_value=30,60
 frame_count

--- a/home/programs/linux-only/mangohud/default.nix
+++ b/home/programs/linux-only/mangohud/default.nix
@@ -1,5 +1,33 @@
-{ pkgs, ... }: {
-  home.file = {
-    ".config/MangoHud/MangoHud.conf".source = ./MangoHud.conf;
+{ lib, config, ... }:
+
+let
+  cfg = config.custom.mangohud;
+  # Cap slightly below the panel's max so VRR stays engaged: at or above max
+  # refresh the frame limiter bounces off the vsync ceiling and VRR disengages.
+  fpsCap = cfg.displayMaxRefresh - 4;
+in
+{
+  options.custom.mangohud = {
+    displayMaxRefresh = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      example = 120;
+      description = ''
+        Max refresh rate (Hz) of this machine's gaming display. When set,
+        MangoHud caps games at 4 fps below it (VRR-friendly), with
+        toggle_fps_limit (Shift_L+F1) switching back to uncapped.
+        null leaves games uncapped.
+      '';
+    };
+  };
+
+  config = {
+    home.file.".config/MangoHud/MangoHud.conf".text =
+      builtins.readFile ./MangoHud.conf
+      + (if cfg.displayMaxRefresh != null then ''
+        fps_limit=${toString fpsCap},0
+      '' else ''
+        fps_limit=0
+      '');
   };
 }


### PR DESCRIPTION
## Overview
Adds a per-host VRR-friendly FPS cap for MangoHud so games stop bouncing off the vsync ceiling on VRR panels.

## Changes
- New home-manager option `custom.mangohud.displayMaxRefresh` (nullable int). When set, the generated MangoHud config caps games at 4fps below the panel's max refresh (`fps_limit=<cap>,0`) so VRR stays engaged instead of the frame rate bouncing off the vsync ceiling, which presents as periodic judder. `Shift_L+F1` still toggles back to uncapped. Hosts that leave the option unset keep the prior uncapped behaviour (`fps_limit=0`).
- Moved the static `fps_limit=0` line out of `home/programs/linux-only/mangohud/MangoHud.conf` and into the module so the value can be computed per-host.
- `ali-desktop` sets `displayMaxRefresh = 120` (Samsung G9, 120Hz) -> 116fps cap.

## Context
Verified with `nix eval`: the generated `ali-desktop` config ends with `fps_limit=116,0`, while `ali-framework-laptop` (option unset) still ends with `fps_limit=0`.

Follow-up: other hosts can opt in by setting their panel's refresh rate with a single line in their home-manager.users block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFHzV8pYR8uiNRuGaxBSdY
