### PR TITLE
Steam Deck: stay awake on AC, hibernate only on battery

### DIFF
--- a/flake-modules/hosts/ali-steam-deck/default.nix
+++ b/flake-modules/hosts/ali-steam-deck/default.nix
@@ -411,7 +411,7 @@ in {
         # Jovian manages the power button via its own daemon (powerbuttond)
         services.logind.settings.Login.HandlePowerKey = lib.mkForce "ignore";
 
-        # Auto-hibernate after 30m of suspend so the battery doesn't drain
+        # Auto-hibernate after 4h of suspend so the battery doesn't drain
         # flat when the deck is left suspended (e.g. in a bag). Both the
         # Steam UI Suspend button and KDE powerdevil call plain `suspend`
         # via logind's dbus Suspend() method, which bypasses
@@ -424,10 +424,10 @@ in {
         # the user resumes manually first. Requires the swap LV in
         # disko-config to be marked resumeDevice=true (it is).
         #
-        # 30m balances quick-resume (put-downs stay in S3, where waking is
+        # 4h balances quick-resume (put-downs stay in S3, where waking is
         # instant and doesn't need the LUKS controller-PIN dance) against
         # bag-safety: the Deck's S3 draws a few %/hr, so a full charge
-        # survives a 30m window comfortably.
+        # survives a 4h window comfortably.
         #
         # On AC the hibernation is pointless — nothing is draining — but the
         # alarm is still armed, because the power state can change while the
@@ -440,7 +440,7 @@ in {
         #
         # Net effect: unplugging a suspended, plugged-in Deck — putting it in
         # a bag — is picked up within one interval and hibernates as it would
-        # have on battery, at the cost of a brief wake every 30m while it sits
+        # have on battery, at the cost of a brief wake every 4h while it sits
         # asleep on the charger.
         systemd.services.auto-hibernate-after-suspend = {
           description = "Hibernate an extended suspend, or re-check later if on AC";
@@ -511,14 +511,14 @@ in {
           };
         };
         systemd.timers.auto-hibernate-after-suspend = {
-          description = "Trigger hibernate after 30m in suspend";
+          description = "Trigger hibernate after 4h in suspend";
           # Armed on every suspend regardless of power source — the service it
           # triggers is what decides between hibernating and going back to
           # sleep. partOf cancels it when the user resumes manually.
           wantedBy = [ "suspend.target" ];
           partOf = [ "suspend.target" ];
           timerConfig = {
-            OnActiveSec = "30m";
+            OnActiveSec = "4h";
             AccuracySec = "1m";
             WakeSystem = true;
             RemainAfterElapse = false;

--- a/flake-modules/hosts/ali-steam-deck/default.nix
+++ b/flake-modules/hosts/ali-steam-deck/default.nix
@@ -102,10 +102,7 @@ in {
       # Host-specific configuration
       ({ config, lib, outputs, pkgs, username, ... }:
       let
-        # Exit 0 on battery, 1 while any mains supply is online. Used as an
-        # ExecCondition, where a non-zero exit marks the unit *skipped* rather
-        # than failed — so the OnFailure hook on systemd-hibernate below is
-        # not triggered by the guard itself.
+        # Exit 0 on battery, 1 while any mains supply is online.
         #
         # Globs every power_supply rather than hardcoding ACAD: the Deck's
         # dock/USB-C PD supplies show up under their own names, and charging
@@ -427,29 +424,51 @@ in {
         # the user resumes manually first. Requires the swap LV in
         # disko-config to be marked resumeDevice=true (it is).
         #
-        # 30m balances quick-resume (short put-downs stay in S3) against
-        # bag-safety (the Deck's S3 still draws a few %/hr, so 2h could
-        # noticeably drain before hibernating). Tune as desired.
+        # 30m balances quick-resume (put-downs stay in S3, where waking is
+        # instant and doesn't need the LUKS controller-PIN dance) against
+        # bag-safety: the Deck's S3 draws a few %/hr, so a full charge
+        # survives a 30m window comfortably.
         #
-        # None of this applies on AC: the drain the escalation exists to avoid
-        # doesn't happen while charging, and a plugged-in Deck should stay
-        # awake and reachable. The arm service below therefore skips arming
-        # the RTC alarm entirely when suspending on mains — so the Deck isn't
-        # woken every 30m for nothing — and the hibernate service re-checks,
-        # covering a suspend that started on battery and was plugged in before
-        # the alarm fired.
+        # On AC the hibernation is pointless — nothing is draining — but the
+        # alarm is still armed, because the power state can change while the
+        # Deck is asleep and nothing on a suspended machine can observe that:
+        # in S3 the CPU is halted, so a udev rule on power_supply `online`
+        # only ever runs *after* something else has already woken the system.
+        # The RTC alarm is that something else. Each wake therefore re-checks
+        # the power source and either hibernates (on battery) or goes straight
+        # back to suspend (on AC), which re-arms the alarm for the next check.
+        #
+        # Net effect: unplugging a suspended, plugged-in Deck — putting it in
+        # a bag — is picked up within one interval and hibernates as it would
+        # have on battery, at the cost of a brief wake every 30m while it sits
+        # asleep on the charger.
         systemd.services.auto-hibernate-after-suspend = {
-          description = "Hibernate after extended suspend to save battery";
+          description = "Hibernate an extended suspend, or re-check later if on AC";
           serviceConfig = {
             Type = "oneshot";
-            ExecCondition = lib.getExe onBattery;
             # NB: `systemctl hibernate` returns as soon as logind queues the
             # job, ~24s before the kernel actually attempts the image write,
             # so its exit status says nothing about whether hibernation
             # worked. Failure is handled by the OnFailure hook on
             # systemd-hibernate.service below, which is the unit that does
             # report a real result.
-            ExecStart = "${pkgs.systemd}/bin/systemctl hibernate";
+            ExecStart = lib.getExe (pkgs.writeShellApplication {
+              name = "deck-suspend-escalate";
+              runtimeInputs = [ pkgs.systemd ];
+              text = ''
+                if ${lib.getExe onBattery}; then
+                  systemctl hibernate
+                else
+                  # Still on mains: nothing to save, so drop back into S3.
+                  # Re-entering suspend.target re-arms the timer, so the power
+                  # source is checked again one interval from now. The settle
+                  # delay mirrors hibernate-fallback-suspend below: systemd-sleep
+                  # has only just thawed user.slice on this wake.
+                  sleep 5
+                  systemctl suspend
+                fi
+              '';
+            });
           };
         };
 
@@ -491,34 +510,12 @@ in {
             ExecStart = "${pkgs.systemd}/bin/systemctl suspend";
           };
         };
-        # Arms the timer below on suspend, but only on battery. The timer is
-        # deliberately not `wantedBy = suspend.target` itself: systemd has no
-        # way to express "start this timer unless mains is online", and a
-        # timer unit's own Condition* checks can't read a sysfs *value*.
-        systemd.services.auto-hibernate-arm = {
-          description = "Arm the auto-hibernate timer when suspending on battery";
-          # wantedBy suspend.target (not sleep.target) so this only arms for
-          # suspend, never for a hibernate that is already under way.
-          # suspend.target itself is ordered *after* systemd-suspend.service —
-          # i.e. after resume — so the ordering has to name that service
-          # directly to arm the RTC alarm before the machine goes down.
-          # DefaultDependencies=no keeps the usual basic.target ordering from
-          # deadlocking against the sleep transaction.
-          wantedBy = [ "suspend.target" ];
-          partOf = [ "suspend.target" ];
-          before = [ "systemd-suspend.service" ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig = {
-            Type = "oneshot";
-            ExecCondition = lib.getExe onBattery;
-            ExecStart = "${pkgs.systemd}/bin/systemctl start auto-hibernate-after-suspend.timer";
-          };
-        };
-
         systemd.timers.auto-hibernate-after-suspend = {
           description = "Trigger hibernate after 30m in suspend";
-          # Started by auto-hibernate-arm.service above, not by suspend.target
-          # directly. partOf stays so a manual resume still cancels it.
+          # Armed on every suspend regardless of power source — the service it
+          # triggers is what decides between hibernating and going back to
+          # sleep. partOf cancels it when the user resumes manually.
+          wantedBy = [ "suspend.target" ];
           partOf = [ "suspend.target" ];
           timerConfig = {
             OnActiveSec = "30m";

--- a/flake-modules/hosts/ali-steam-deck/default.nix
+++ b/flake-modules/hosts/ali-steam-deck/default.nix
@@ -100,7 +100,29 @@ in {
       }
 
       # Host-specific configuration
-      ({ config, lib, outputs, pkgs, username, ... }: {
+      ({ config, lib, outputs, pkgs, username, ... }:
+      let
+        # Exit 0 on battery, 1 while any mains supply is online. Used as an
+        # ExecCondition, where a non-zero exit marks the unit *skipped* rather
+        # than failed — so the OnFailure hook on systemd-hibernate below is
+        # not triggered by the guard itself.
+        #
+        # Globs every power_supply rather than hardcoding ACAD: the Deck's
+        # dock/USB-C PD supplies show up under their own names, and charging
+        # over any of them counts as plugged in.
+        onBattery = pkgs.writeShellApplication {
+          name = "deck-on-battery";
+          text = ''
+            for supply in /sys/class/power_supply/*; do
+              [ -r "$supply/type" ] || continue
+              [ "$(cat "$supply/type")" = "Mains" ] || continue
+              if [ "$(cat "$supply/online" 2>/dev/null || echo 0)" = "1" ]; then
+                exit 1
+              fi
+            done
+          '';
+        };
+      in {
         # deploy-rs wraps the system profile in an `activatable-nixos-system`
         # layer, adding a symlink hop. jovian-stubs' steamos-update compares
         # `readlink /run/booted-system/kernel` vs `readlink
@@ -408,10 +430,19 @@ in {
         # 30m balances quick-resume (short put-downs stay in S3) against
         # bag-safety (the Deck's S3 still draws a few %/hr, so 2h could
         # noticeably drain before hibernating). Tune as desired.
+        #
+        # None of this applies on AC: the drain the escalation exists to avoid
+        # doesn't happen while charging, and a plugged-in Deck should stay
+        # awake and reachable. The arm service below therefore skips arming
+        # the RTC alarm entirely when suspending on mains — so the Deck isn't
+        # woken every 30m for nothing — and the hibernate service re-checks,
+        # covering a suspend that started on battery and was plugged in before
+        # the alarm fired.
         systemd.services.auto-hibernate-after-suspend = {
           description = "Hibernate after extended suspend to save battery";
           serviceConfig = {
             Type = "oneshot";
+            ExecCondition = lib.getExe onBattery;
             # NB: `systemctl hibernate` returns as soon as logind queues the
             # job, ~24s before the kernel actually attempts the image write,
             # so its exit status says nothing about whether hibernation
@@ -460,9 +491,34 @@ in {
             ExecStart = "${pkgs.systemd}/bin/systemctl suspend";
           };
         };
+        # Arms the timer below on suspend, but only on battery. The timer is
+        # deliberately not `wantedBy = suspend.target` itself: systemd has no
+        # way to express "start this timer unless mains is online", and a
+        # timer unit's own Condition* checks can't read a sysfs *value*.
+        systemd.services.auto-hibernate-arm = {
+          description = "Arm the auto-hibernate timer when suspending on battery";
+          # wantedBy suspend.target (not sleep.target) so this only arms for
+          # suspend, never for a hibernate that is already under way.
+          # suspend.target itself is ordered *after* systemd-suspend.service —
+          # i.e. after resume — so the ordering has to name that service
+          # directly to arm the RTC alarm before the machine goes down.
+          # DefaultDependencies=no keeps the usual basic.target ordering from
+          # deadlocking against the sleep transaction.
+          wantedBy = [ "suspend.target" ];
+          partOf = [ "suspend.target" ];
+          before = [ "systemd-suspend.service" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "oneshot";
+            ExecCondition = lib.getExe onBattery;
+            ExecStart = "${pkgs.systemd}/bin/systemctl start auto-hibernate-after-suspend.timer";
+          };
+        };
+
         systemd.timers.auto-hibernate-after-suspend = {
           description = "Trigger hibernate after 30m in suspend";
-          wantedBy = [ "suspend.target" ];
+          # Started by auto-hibernate-arm.service above, not by suspend.target
+          # directly. partOf stays so a manual resume still cancels it.
           partOf = [ "suspend.target" ];
           timerConfig = {
             OnActiveSec = "30m";

--- a/home/machines/ali-steam-deck/default.nix
+++ b/home/machines/ali-steam-deck/default.nix
@@ -26,7 +26,8 @@
 
   # Plugged in, the Deck should stay awake and only blank its panel — it is a
   # small always-on machine when docked, and the NixOS host config likewise
-  # refuses to auto-hibernate on mains (see the auto-hibernate-arm service in
+  # only hibernates a suspend that is running on battery (see
+  # auto-hibernate-after-suspend in
   # flake-modules/hosts/ali-steam-deck/default.nix). This covers the Plasma
   # session — both "Switch to Desktop" and the desktop-mode specialisation;
   # Gaming Mode's idle sleep is Steam's own timer and is set in its UI.

--- a/home/machines/ali-steam-deck/default.nix
+++ b/home/machines/ali-steam-deck/default.nix
@@ -24,6 +24,18 @@
   # kglobalshortcutsrc as "none".
   programs.plasma.shortcuts.ksmserver."Lock Session" = [ ];
 
+  # Plugged in, the Deck should stay awake and only blank its panel — it is a
+  # small always-on machine when docked, and the NixOS host config likewise
+  # refuses to auto-hibernate on mains (see the auto-hibernate-arm service in
+  # flake-modules/hosts/ali-steam-deck/default.nix). This covers the Plasma
+  # session — both "Switch to Desktop" and the desktop-mode specialisation;
+  # Gaming Mode's idle sleep is Steam's own timer and is set in its UI.
+  # Battery profiles are left at powerdevil's defaults.
+  programs.plasma.powerdevil.AC = {
+    autoSuspend.action = "nothing";
+    turnOffDisplay.idleTimeout = 600;
+  };
+
   # swayidle comes from the same niri stack and locks the session after 900s
   # idle (and on the `lock` event) via lock-session — which is exactly the
   # lockout above, and it fires regardless of the Plasma settings. Its


### PR DESCRIPTION
## Why

Left idle **while plugged in**, `ali-steam-deck` suspended and then hibernated 30 minutes later, so a docked Deck ended up powered off. Evidence (`journalctl -u systemd-logind`, boot -1):

```
2026-08-20T01:01:19  The system will suspend now!      <- no "Power key pressed short." before it
2026-08-20T01:31:26  Operation 'suspend' finished.
2026-08-20T01:31:26  The system will hibernate now!
```

Suspends without a preceding power-key line come from the Steam client's own idle timer calling logind `Suspend()` — not gamescope, not logind `IdleAction` (already `ignore`), and Jovian-NixOS exposes no idle/sleep option. Steam's timeout stays a manual Gaming Mode setting (its `IdleSuspend*` keys don't exist in `config.vdf` until first changed, so pre-seeding them from Nix would be racy). What this PR fixes is the hibernate escalation that lives in this repo, plus the Plasma session.

## What

- `deck-on-battery`: exits non-zero while any `power_supply` of type `Mains` is `online`. Globs rather than hardcoding `ACAD`, since dock/PD supplies appear under their own names.
- The RTC alarm is still armed on every suspend; the service it triggers now re-checks the power source and either hibernates (battery) or re-suspends (AC), which re-arms the alarm. Simply skipping the alarm on AC — the first commit here — left "suspended on the charger, then unplugged" unable to ever hibernate: in S3 the CPU is halted, so a udev rule on `power_supply` can only run once something else has woken the machine.
- Interval 30m → **4h**. Hibernation on this hardware fails ~half the time and resuming needs the LUKS controller-PIN dance, so short put-downs should stay in S3.
- Plasma `powerdevil.AC`: no auto-suspend, display off at 10 min — covers "Switch to Desktop" and the `desktop-mode` specialisation.

## Verified

Built, deployed to the Deck with deploy-rs, and checked live:

- `deck-on-battery` exits 1 on the Deck while `ACAD/online == 1`, 0 otherwise.
- timer: `WantedBy=suspend.target`, `PartOf=suspend.target`, `OnActiveSec=4h`; starting it by hand arms and cancels cleanly.
- escalate script on disk takes the re-suspend branch on mains.

Not yet exercised: a real suspend → wake → re-suspend cycle on AC and a suspend → wake → hibernate cycle on battery. Whether a USB-C detach wakes the Deck from S3 at all is untested — if it does, an immediate udev-triggered hibernate could be layered on top of this polling.