### PR TITLE
ci: stop the cache build triggering on pushes to main

### DIFF
--- a/.github/workflows/build-and-cache.yaml
+++ b/.github/workflows/build-and-cache.yaml
@@ -1,9 +1,13 @@
 name: Build and Cache Nix Flake
 
 on:
-  push:
-    branches:
-      - main
+  # Deliberately NOT push-to-main: this build saturates the self-hosted
+  # runner's disk, which the k8s node shares with the media server's
+  # postgres. A daytime PR merge kicking it off froze a watch party twice
+  # on 2026-08-24 (pharos T128: 78s SELECTs while nix built). The nightly
+  # 02:00 UTC lock-update chains into this via workflow_run below, so the
+  # cache still refreshes daily; merged-but-unbuilt changes wait for that
+  # (or a manual dispatch) instead of competing with evening playback.
   workflow_dispatch:
     inputs:
       force_push:


### PR DESCRIPTION
Every PR merge ran "Build and Cache Nix Flake" on the self-hosted runner immediately. That build saturates the disk the k8s node shares with pharos's postgres — the 21:00 merge tonight froze a SyncPlay watch party twice, with postgres SELECTs at 78–83s while nix built (pharos T128).

The nightly 02:00 UTC "Update and push flake lock" already chains into this workflow via `workflow_run`, so the cache still refreshes every night; merged-but-unbuilt changes wait for that or a manual `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)